### PR TITLE
Ignore empty path elements in resource ID of new managed object (#6)

### DIFF
--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ObjectClassInfoHelper.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ObjectClassInfoHelper.java
@@ -234,7 +234,7 @@ public class ObjectClassInfoHelper {
                 }
             }
             if (newResourceId != null) {
-                fullId = fullId.concat(newResourceId);
+                fullId = fullId.concat(new ResourcePath(newResourceId));
             }
         }
         return urlDecode(fullId.toString());


### PR DESCRIPTION
Created workaround for building resource identifier with leading slash. 