### PR TITLE
Fixed empty request audit name (#9)

### DIFF
--- a/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletConnectionFactory.java
+++ b/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletConnectionFactory.java
@@ -330,7 +330,7 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
                         } finally {
                             measure.end();
                         }
-                    }                    
+                    }
                     @Override
                     public Promise<ActionResponse, ResourceException> actionAsync(
                             Context context, ActionRequest request) {
@@ -367,7 +367,7 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
                     }
                 };
             }
-            
+
             @Override
             public Promise<Connection, ResourceException> getConnectionAsync() {
                 try {
@@ -376,21 +376,21 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
                     return e.asPromise();
                 }
             }
-           
+
             /**
              * @param request the router request
              * @return an event name For monitoring purposes
              */
             private Name getRouterEventName(Request request) {
                 RequestType requestType = request.getRequestType();
-                String idContext;
+                String idContext = "";
 
                 // For query and action group statistics by full URI
                 // Create has only the component name in the getResourceName to start with
-                if (RequestType.QUERY.equals(requestType) || RequestType.ACTION.equals(requestType) 
+                if (RequestType.QUERY.equals(requestType) || RequestType.ACTION.equals(requestType)
                         || RequestType.CREATE.equals(requestType)) {
                     idContext = request.getResourcePath();
-                } else {
+                } else if (request.getResourcePathObject().size() > 1) {
                     // For RUD, patch group statistics without the local resource identifier
                     idContext = request.getResourcePathObject()
                             .head(request.getResourcePathObject().size() - 1)
@@ -398,7 +398,7 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
                 }
 
                 String eventName = EVENT_ROUTER_PREFIX + idContext + "/" + requestType.toString().toLowerCase();
-                
+
                 return Name.get(eventName);
             }
         };


### PR DESCRIPTION
The name of the audit request event can sometimes be empty, because the id context used in getting the name can be null, and then it is trying to get an event name with "null" in it.