### PR TITLE
Storing of task variables into local scope during task completion (#25)

### DIFF
--- a/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/TaskInstanceResource.java
+++ b/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/TaskInstanceResource.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2017 Wren Security
  */
 package org.forgerock.openidm.workflow.activiti.impl;
 
@@ -110,7 +111,7 @@ public class TaskInstanceResource implements CollectionResourceProvider {
                 if ("claim".equals(request.getAction())) {
                     taskService.claim(resourceId, request.getContent().expect(Map.class).asMap().get("userId").toString());
                 } else if ("complete".equals(request.getAction())) {
-                    taskService.complete(resourceId, request.getContent().expect(Map.class).asMap());
+                    taskService.complete(resourceId, request.getContent().expect(Map.class).asMap(), true);
                 } else {
                     return new BadRequestException("Unknown action").asPromise();
                 }

--- a/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/TaskInstanceResource.java
+++ b/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/TaskInstanceResource.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions copyright 2017 Wren Security
+ * Portions Copyright 2017 Wren Security
  */
 package org.forgerock.openidm.workflow.activiti.impl;
 


### PR DESCRIPTION
Implemented storing of task variables into task local scope during task completion. Now, both `proc_inst_id_` and `task_id_` columns will be filled in database table `act_hi_varinst`. 