### PR TITLE
Issue #33 - Fix `needsResetPassword` Mapping Error

### DIFF
--- a/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/UserModel.js
+++ b/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/UserModel.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2018 Rosie Applications, Inc.
  */
 
 define([
@@ -101,9 +102,6 @@ define([
         },
         parse: function (response) {
             if (_.has(response, "password")) {
-                if (_.isString(response.password)) {
-                    response.needsResetPassword = true;
-                }
                 // usually password won't be included in the response, but it will for openidm-admin
                 delete response.password;
             }


### PR DESCRIPTION
This was apparently dead code from OpenIDM 3.x that now causes problems in OpenIDM 5.x because all fields on user objects are persisted, and there was no mapping for JDBC.

Closes #33.