### PR TITLE
Issue #11 - React to UID Changes during ICF Update

### DIFF
--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncOperation.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncOperation.java
@@ -11,23 +11,28 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Portions copyright 2011-2016 ForgeRock AS.
+ * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.forgerock.openidm.sync.impl;
 
-import static org.forgerock.json.JsonValue.*;
-import static org.forgerock.json.resource.Requests.*;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.forgerock.json.resource.Requests.newCreateRequest;
+import static org.forgerock.json.resource.Requests.newDeleteRequest;
+import static org.forgerock.json.resource.Requests.newUpdateRequest;
 
-import javax.script.ScriptException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import javax.script.ScriptException;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
+import org.forgerock.json.resource.Connection;
 import org.forgerock.json.resource.CreateRequest;
 import org.forgerock.json.resource.DeleteRequest;
 import org.forgerock.json.resource.NotFoundException;
@@ -482,6 +487,7 @@ abstract class SyncOperation {
                         case UPDATE:
                         case LINK:
                             String targetId = getTargetObjectId();
+
                             if (getTargetObjectId() == null) {
                                 throw new SynchronizationException("no target object to link");
                             }
@@ -510,24 +516,32 @@ abstract class SyncOperation {
                                     }
                                 }
                             }
-                            if (objectMapping.isLinkingEnabled() && linkObject._id != null && !linkObject.targetEquals(targetId)) {
-                                linkObject.targetId = targetId;
-                                linkObject.update(context);
-                            }
+
+                            updateTargetLink(context, targetId);
+
                             // TODO: Detect change of source id, and update link accordingly.
                             if (action == ReconAction.CREATE || action == ReconAction.LINK) {
                                 execScript("postMapping", postMapping);
                                 break; // do not update target
                             }
-                            if (getSourceObject() != null && getTargetObject() != null) {
-                                applyMappings(context, getSourceObject(), oldValue, getTargetObject(), oldTarget,
-                                        linkObject.linkQualifier, reconContext);
+
+                            JsonValue sourceObject  = getSourceObject();
+                            JsonValue updatedTarget = getTargetObject();
+
+                            if ((sourceObject != null) && (updatedTarget != null)) {
+                                applyMappings(
+                                    context, sourceObject, oldValue, updatedTarget, oldTarget,
+                                    linkObject.linkQualifier, reconContext);
+
                                 execScript("onUpdate", onUpdateScript, oldTarget);
+
                                 // only update if target changes
-                                if (!oldTarget.isEqualTo(getTargetObject())) {
-                                    updateTargetObject(context, getTargetObject(), targetId, reconContext);
+                                if (!oldTarget.isEqualTo(updatedTarget)) {
+                                    updateTargetObject(
+                                        context, updatedTarget, targetId, reconContext);
                                 }
                             }
+
                             // execute the defaultPostMapping script to add lastSync attribute to managed user
                             execScript("postMapping", postMapping);
                             break; // terminate UPDATE
@@ -592,6 +606,35 @@ abstract class SyncOperation {
     }
 
     /**
+     * Updates where the current link object points.
+     *
+     * <p>If linking is not enabled, there is currently no link, or the link already points to the
+     * specified link, this method has no effect.
+     *
+     * @param   context
+     *          The context of the current sync request.
+     * @param   targetId
+     *          The ID of the target object to which the link should point.
+     *
+     * @throws  SynchronizationException
+     *          If the link update fails.
+     */
+    private void updateTargetLink(final Context context, final String targetId)
+      throws SynchronizationException {
+        if (objectMapping.isLinkingEnabled()
+            && (linkObject._id != null)
+            && !linkObject.targetEquals(targetId)) {
+            linkObject.targetId = targetId;
+
+            linkObject.update(context);
+
+            LOGGER.debug(
+              "Updated link: {} sourceId: {} targetId: {}",
+              linkObject._id, linkObject.sourceId, linkObject.targetId);
+        }
+    }
+
+    /**
      * Evaluates a post action
      * @param sourceAction sourceAction true if the {@link ReconAction} is determined for the
      * {@link SourceSyncOperation}
@@ -610,12 +653,17 @@ abstract class SyncOperation {
     protected void createLink(Context context, String sourceId, String targetId, String reconId)
             throws SynchronizationException {
         Link linkObject = new Link(objectMapping);
+
         linkObject.setLinkQualifier(this.linkObject.linkQualifier);
+
         execScript("onLink", onLinkScript);
+
         linkObject.sourceId = sourceId;
         linkObject.targetId = targetId;
+
         linkObject.create(context);
         initializeLink(linkObject);
+
         LOGGER.debug("Established link sourceId: {} targetId: {} in reconId: {}", sourceId, targetId, reconId);
     }
 
@@ -822,7 +870,7 @@ abstract class SyncOperation {
      * Issues a request to update an object on the target.
      *
      * @param context the Context to use for the request
-     * @param target the target object to create.
+     * @param target the target object to update.
      * @param reconContext Recon context or {@code null}
      * @throws SynchronizationException
      */
@@ -830,19 +878,37 @@ abstract class SyncOperation {
             ReconciliationContext reconContext) throws SynchronizationException {
         EventEntry measure = Publisher.start(ObjectMapping.EVENT_UPDATE_TARGET, target, null);
         final long startNanoTime = ObjectMapping.startNanoTime(reconContext);
+
         try {
+            final LinkType linkType = objectMapping.getLinkType();
             final String id = target.get("_id").required().asString();
-            final String fullId = LazyObjectAccessor.qualifiedId(objectMapping.getTargetObjectSet(), id);
+            final String fullId;
+            final String normalizedIdParam = linkType.normalizeTargetId(targetId);
+            final String normalizedTargetId = linkType.normalizeTargetId(id);
+            final UpdateRequest request;
+            final ResourceResponse updateResponse;
+            final Connection connection = objectMapping.getConnectionFactory().getConnection();
+
+            fullId = LazyObjectAccessor.qualifiedId(objectMapping.getTargetObjectSet(), id);
+
             // Do simple comparison first, only if it fails handle case sensitivity
-            if (!targetId.equals(id) &&
-                    !objectMapping.getLinkType().normalizeTargetId(targetId).equals(objectMapping.getLinkType().normalizeTargetId(id))) {
+            if (!targetId.equals(id) && !normalizedIdParam.equals(normalizedTargetId)) {
                 throw new SynchronizationException("target '_id' has changed");
             }
+
             LOGGER.trace("Update target object {}", fullId);
-            UpdateRequest request = newUpdateRequest(fullId, target)
-                    .setRevision(target.get("_rev").asString());
-            objectMapping.getConnectionFactory().getConnection().update(context, request);
+
+            request = newUpdateRequest(fullId, target).setRevision(target.get("_rev").asString());
+            updateResponse = connection.update(context, request);
+
             measure.setResult(target);
+
+            if (updateResponse != null) {
+                final String updatedTargetId = updateResponse.getId();
+
+                // Handle potential UID target change during update
+                updateTargetLink(context, updatedTargetId);
+            }
         } catch (SynchronizationException se) {
             throw se;
         } catch (JsonValueException jve) {

--- a/openidm-core/src/test/java/org/forgerock/openidm/sync/impl/ObjectMappingTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/sync/impl/ObjectMappingTest.java
@@ -11,7 +11,8 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Portions copyright 2014-2016 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -21,31 +22,37 @@ import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.net.URL;
 import java.util.Map;
 import javax.script.Bindings;
-
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
+import org.forgerock.json.resource.Connection;
 import org.forgerock.json.resource.ConnectionFactory;
-import org.forgerock.openidm.sync.SynchronizationException;
+import org.forgerock.json.resource.ResourceResponse;
+import org.forgerock.json.resource.Responses;
+import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.sync.ReconAction;
 import org.forgerock.openidm.sync.ReconContext;
+import org.forgerock.openidm.sync.SynchronizationException;
 import org.forgerock.openidm.util.Scripts;
-import org.forgerock.script.ScriptRegistry;
 import org.forgerock.script.Script;
 import org.forgerock.script.ScriptEntry;
+import org.forgerock.script.ScriptRegistry;
 import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ObjectMappingTest {
 
@@ -114,23 +121,138 @@ public class ObjectMappingTest {
         ));
         
         ObjectSetContext.push(new ReconContext(new RootContext("test_id"), dummyMapping.getName()));
+
         SyncOperation testSyncOperation = dummyMapping.getSyncOperation();
+
         testSyncOperation.situation = Situation.CONFIRMED;
         testSyncOperation.action = ReconAction.UPDATE;
         testSyncOperation.sourceObjectAccessor = new LazyObjectAccessor(null, null, "source1", json(null));
         testSyncOperation.targetObjectAccessor = new LazyObjectAccessor(null, null, "target1", null);
+
         dummyMapping.linkType = mock(LinkType.class);
         
         Link link = new Link(dummyMapping);
+
         link._id = "testId";
         link._rev = "testRev";
         link.setLinkQualifier("default");
         link.sourceId = testSyncOperation.sourceObjectAccessor.getLocalId();
         link.targetId = testSyncOperation.targetObjectAccessor.getLocalId();
+
         testSyncOperation.initializeLink(link);
         
         // Test that UPDATE action does not throw a NPE if targetObject == null
         testSyncOperation.performAction();
+    }
+
+    @Test
+    public void testUpdateActionWithTargetUidChange() throws Exception {
+        final ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+        final Connection mockConnection = mock(Connection.class);
+        final TestObjectMapping dummyMapping;
+        final SyncOperation testSyncOperation;
+        final String targetResourceIdAfterUpdate;
+        final JsonValue dummySourceObject;
+        final JsonValue dummyTargetObjectBeforeUpdate;
+        final JsonValue dummyTargetObjectAfterUpdate;
+        final ResourceResponse mockUpdateResponse;
+        final LinkType linkType = mock(LinkType.class);
+
+        // Setup
+        targetResourceIdAfterUpdate = "targetObject2";
+
+        dummyMapping = new TestObjectMapping(mockConnectionFactory, json(
+            object(
+                field("name", "testMapping"),
+                field("source", "testSource"),
+                field("target", "testTarget"),
+                field("properties", array(
+                    object(
+                        field("source", "sourceField1"),
+                        field("target", "targetField1"),
+                        field("transform", ""),
+                        field("default", "")
+                    )
+                ))
+            )
+        ));
+
+        dummySourceObject = json(
+            object(
+                field("_id", "sourceObject1"),
+                field("sourceField1", "abracadabra")
+            )
+        );
+
+        dummyTargetObjectBeforeUpdate = json(
+            object(
+                field("_id", "targetObject1"),
+                field("targetField1", "tada")
+            )
+        );
+
+        dummyTargetObjectAfterUpdate = json(
+          object(
+            field("_id", targetResourceIdAfterUpdate),
+            field("targetField1", "abracadabra")
+          )
+        );
+
+        // Stub out normalizeTargetId
+        when(linkType.normalizeTargetId(anyString()))
+            .thenAnswer(new Answer<String>() {
+                @Override
+                public String answer(InvocationOnMock invocation) {
+                    Object[] args = invocation.getArguments();
+
+                    return (String)args[0];
+                }
+            });
+
+
+        ObjectSetContext.push(new ReconContext(new RootContext("test_id"), dummyMapping.getName()));
+
+        testSyncOperation = dummyMapping.getSyncOperation();
+        testSyncOperation.situation = Situation.CONFIRMED;
+        testSyncOperation.action = ReconAction.UPDATE;
+
+        testSyncOperation.sourceObjectAccessor =
+          new LazyObjectAccessor(
+            mockConnectionFactory, null, "sourceObject1", dummySourceObject);
+
+        testSyncOperation.targetObjectAccessor =
+          new LazyObjectAccessor(
+            mockConnectionFactory, null, "targetObject1", dummyTargetObjectBeforeUpdate);
+
+        dummyMapping.linkType = linkType;
+
+        Link link = new Link(dummyMapping);
+
+        link._id = "testId";
+        link._rev = "testRev";
+        link.sourceId = testSyncOperation.sourceObjectAccessor.getLocalId();
+        link.targetId = testSyncOperation.targetObjectAccessor.getLocalId();
+
+        link.setLinkQualifier("default");
+
+        testSyncOperation.initializeLink(link);
+
+        // Stub out the ICF update operation
+        mockUpdateResponse =
+          Responses.newResourceResponse(
+            targetResourceIdAfterUpdate, "0", dummyTargetObjectAfterUpdate);
+
+        Mockito
+          .doReturn(mockUpdateResponse)
+          .when(mockConnection).update(any(Context.class), any(UpdateRequest.class));
+
+        when(mockConnectionFactory.getConnection()).thenReturn(mockConnection);
+
+        // Run test
+        testSyncOperation.performAction();
+
+        // Check assertions -- the link should point to the new target
+        assertThat(testSyncOperation.linkObject.targetId).isEqualTo(targetResourceIdAfterUpdate);
     }
     
     private TestObjectMapping createObjectMapping(String syncJson) throws Exception {


### PR DESCRIPTION
The documentation for the ICF Update SPI very clearly states that the UID of an object can change, which is why that operation returns the updated UID. Unfortunately, though the ICF provisioner in IDM goes to great pains to ensure this updated UID gets returned to the sync operation, it appears that it gets ignored by the operation and the link object does not get updated. This issue is present in IDM 4.x and IDM 5.x (including the current release version of IDM 5.5).

This is just a band-aid patch for specifically this issue. However, the entire SyncOperation class badly needs re-factoring. The `performAction()` method alone is 175 lines and contains a nasty, double-nested switch statement with intentional fall-throughs.

Closes #11.