### PR TITLE
Re-factor IdentityServer init. to fix race conditions + tests

### DIFF
--- a/openidm-config/pom.xml
+++ b/openidm-config/pom.xml
@@ -159,6 +159,14 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openidm-config/src/test/java/org/forgerock/openidm/config/manage/ConfigObjectServiceTest.java
+++ b/openidm-config/src/test/java/org/forgerock/openidm/config/manage/ConfigObjectServiceTest.java
@@ -12,25 +12,35 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.config.manage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
+import static org.forgerock.json.resource.Requests.newDeleteRequest;
 import static org.forgerock.json.resource.Requests.newQueryRequest;
-import static org.forgerock.json.resource.Requests.*;
+import static org.forgerock.json.resource.Requests.newReadRequest;
+import static org.forgerock.json.resource.Requests.newUpdateRequest;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 import static org.forgerock.openidm.config.manage.ConfigObjectService.asConfigQueryFilter;
 import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.*;
+import static org.testng.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -42,7 +52,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.BadRequestException;
@@ -68,6 +77,7 @@ import org.forgerock.openidm.config.crypto.ConfigCrypto;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.config.enhanced.JSONEnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.metadata.impl.ProviderListener;
 import org.forgerock.openidm.patch.PatchValueTransformer;
 import org.forgerock.openidm.patch.ScriptedPatchValueTransformer;
@@ -109,6 +119,8 @@ public class ConfigObjectServiceTest {
     @SuppressWarnings("unchecked")
 	@BeforeTest
     public void beforeTest() throws Exception {
+        IdentityServerTestUtils.initInstanceForTest();
+
         properties = new Hashtable<>();
         properties.put(ComponentConstants.COMPONENT_NAME, getClass().getName());
 

--- a/openidm-config/src/test/java/org/forgerock/openidm/config/manage/ConfigObjectServiceTest.java
+++ b/openidm-config/src/test/java/org/forgerock/openidm/config/manage/ConfigObjectServiceTest.java
@@ -77,7 +77,7 @@ import org.forgerock.openidm.config.crypto.ConfigCrypto;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.config.enhanced.JSONEnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.metadata.impl.ProviderListener;
 import org.forgerock.openidm.patch.PatchValueTransformer;
 import org.forgerock.openidm.patch.ScriptedPatchValueTransformer;

--- a/openidm-core/pom.xml
+++ b/openidm-core/pom.xml
@@ -158,12 +158,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
-            <artifactId>script-groovy</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
@@ -185,6 +179,20 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.commons</groupId>
+            <artifactId>script-groovy</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openidm-core/src/test/java/org/forgerock/openidm/managed/ManagedObjectSetTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/managed/ManagedObjectSetTest.java
@@ -68,7 +68,7 @@ import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.Router;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.audit.util.NullActivityLogger;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.CryptoService;
 import org.forgerock.openidm.crypto.impl.CryptoServiceImpl;
 import org.forgerock.openidm.repo.QueryConstants;

--- a/openidm-core/src/test/java/org/forgerock/openidm/managed/ManagedObjectSetTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/managed/ManagedObjectSetTest.java
@@ -12,25 +12,30 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.managed;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.json.JsonValue.*;
-import static org.forgerock.json.resource.Requests.*;
-import static org.forgerock.json.resource.Responses.newResourceResponse;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.forgerock.json.resource.Requests.newActionRequest;
+import static org.forgerock.json.resource.Requests.newCreateRequest;
+import static org.forgerock.json.resource.Requests.newUpdateRequest;
 import static org.forgerock.json.resource.ResourceResponse.FIELD_REVISION;
 import static org.forgerock.json.resource.Resources.newInternalConnectionFactory;
+import static org.forgerock.json.resource.Responses.newResourceResponse;
 import static org.forgerock.json.resource.Router.uriTemplate;
 import static org.forgerock.openidm.managed.ManagedObjectSet.Action.triggerSyncCheck;
 import static org.forgerock.openidm.managed.ManagedObjectSet.CRYPTO_KEY_PTR;
 import static org.forgerock.util.Utils.closeSilently;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -39,31 +44,31 @@ import java.security.KeyStore;
 import java.security.KeyStore.PasswordProtection;
 import java.security.KeyStore.SecretKeyEntry;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.crypto.JsonDecryptFunction;
 import org.forgerock.json.crypto.simple.SimpleDecryptor;
 import org.forgerock.json.crypto.simple.SimpleKeySelector;
 import org.forgerock.json.crypto.simple.SimpleKeyStoreSelector;
-import org.forgerock.json.resource.MemoryBackend;
-import org.forgerock.json.resource.ResourceException;
-import org.forgerock.json.resource.ResourceResponse;
-import org.forgerock.json.resource.Router;
-import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
 import org.forgerock.json.resource.Connection;
+import org.forgerock.json.resource.MemoryBackend;
 import org.forgerock.json.resource.ReadRequest;
+import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourcePath;
+import org.forgerock.json.resource.ResourceResponse;
+import org.forgerock.json.resource.Router;
+import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.audit.util.NullActivityLogger;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.CryptoService;
 import org.forgerock.openidm.crypto.impl.CryptoServiceImpl;
 import org.forgerock.openidm.repo.QueryConstants;
@@ -78,8 +83,8 @@ import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.ResultHandler;
-import org.testng.annotations.Test;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Tests for {@link ManagedObjectSet}
@@ -127,6 +132,8 @@ public class ManagedObjectSetTest {
 
     @BeforeClass
     public void setup() throws Exception {
+        IdentityServerTestUtils.initInstanceForTest();
+
         final Map<String, Object> configuration = new HashMap<>(1);
         configuration.put(getLanguageName(), getConfiguration());
         scriptRegistry = getScriptRegistry(configuration);

--- a/openidm-keystore/pom.xml
+++ b/openidm-keystore/pom.xml
@@ -13,6 +13,7 @@
  ~ information: "Portions copyright [year] [name of copyright owner]".
  ~
  ~ Copyright 2016 ForgeRock AS.
+ ~ Portions Copyright 2017-2018 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -85,6 +86,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
@@ -12,27 +12,34 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.keystore.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.openidm.core.IdentityServer.*;
+import static org.forgerock.openidm.core.IdentityServer.CONFIG_CRYPTO_ALIAS;
+import static org.forgerock.openidm.core.IdentityServer.CONFIG_CRYPTO_ALIAS_SELF_SERVICE;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_PROVIDER;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_TYPE;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_TYPE;
 import static org.forgerock.openidm.core.ServerConstants.JWTSESSION_SIGNING_KEY_ALIAS_PROPERTY;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
 import static org.forgerock.openidm.core.ServerConstants.SELF_SERVICE_CERT_ALIAS;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Collections;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
 import org.forgerock.security.keystore.KeyStoreType;
 import org.forgerock.util.Utils;
@@ -44,15 +51,7 @@ public class DefaultKeyStoreInitializerTest {
     @BeforeClass
     public void setUp() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        System.setProperty(LAUNCHER_PROJECT_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        System.setProperty(LAUNCHER_INSTALL_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        try {
-            IdentityServer.initInstance(null);
-        } catch (final IllegalStateException e) {
-            // tried to reinitialize ignore
-        }
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
     }
 
     @Test

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
@@ -39,7 +39,7 @@ import java.util.Collections;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
 import org.forgerock.security.keystore.KeyStoreType;
 import org.forgerock.util.Utils;

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImplTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import java.security.KeyStore;
 import java.security.Security;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
 import org.forgerock.openidm.keystore.KeyStoreService;
 import org.forgerock.security.keystore.KeyStoreType;

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImplTest.java
@@ -12,20 +12,18 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.keystore.impl;
 
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.Security;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.forgerock.openidm.core.IdentityServer;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
 import org.forgerock.openidm.keystore.KeyStoreService;
 import org.forgerock.security.keystore.KeyStoreType;
@@ -37,15 +35,7 @@ public class KeyStoreManagementServiceImplTest {
     @BeforeClass
     public void setUp() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        System.setProperty(LAUNCHER_PROJECT_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        System.setProperty(LAUNCHER_INSTALL_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        try {
-            IdentityServer.initInstance(null);
-        } catch (final IllegalStateException e) {
-            // tried to reinitialize ignore
-        }
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
     }
 
     @Test

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImplTest.java
@@ -12,45 +12,41 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.keystore.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.openidm.core.IdentityServer.*;
+import static org.forgerock.openidm.core.IdentityServer.CONFIG_CRYPTO_ALIAS;
+import static org.forgerock.openidm.core.IdentityServer.CONFIG_CRYPTO_ALIAS_SELF_SERVICE;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_LOCATION;
 import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_TYPE;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_TYPE;
 import static org.forgerock.openidm.core.ServerConstants.JWTSESSION_SIGNING_KEY_ALIAS_PROPERTY;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
 import static org.forgerock.openidm.core.ServerConstants.SELF_SERVICE_CERT_ALIAS;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Collections;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class KeyStoreServiceImplTest {
-
     @BeforeClass
     public void setUp() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        System.setProperty(LAUNCHER_PROJECT_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        System.setProperty(LAUNCHER_INSTALL_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        try {
-            IdentityServer.initInstance(null);
-        } catch (final IllegalStateException e) {
-            // tried to reinitialize ignore
-        }
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
     }
 
     @Test

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImplTest.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImplTest.java
@@ -34,7 +34,7 @@ import java.security.Security;
 import java.util.Collections;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImplTest.java
@@ -12,26 +12,29 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.keystore.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.openidm.core.IdentityServer.*;
+import static org.forgerock.openidm.core.IdentityServer.HTTPS_KEYSTORE_CERT_ALIAS;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_LOCATION;
 import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_PASSWORD;
-import static org.forgerock.openidm.core.ServerConstants.JWTSESSION_SIGNING_KEY_ALIAS_PROPERTY;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_TYPE;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_TYPE;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Collections;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,15 +42,7 @@ public class TrustStoreServiceImplTest {
     @BeforeClass
     public void setUp() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        System.setProperty(LAUNCHER_PROJECT_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        System.setProperty(LAUNCHER_INSTALL_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        try {
-            IdentityServer.initInstance(null);
-        } catch (final IllegalStateException e) {
-            // tried to reinitialize ignore
-        }
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
     }
 
     @Test

--- a/openidm-maintenance/pom.xml
+++ b/openidm-maintenance/pom.xml
@@ -135,12 +135,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
-            <artifactId>forgerock-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
@@ -155,6 +149,20 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.commons</groupId>
+            <artifactId>forgerock-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImplTest.java
+++ b/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImplTest.java
@@ -12,17 +12,19 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.maintenance.upgrade;
 
-import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.array;
 import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -30,13 +32,14 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -55,6 +58,11 @@ public class UpdateManagerImplTest {
             new ArrayList<>(Arrays.asList(Paths.get("security/keystore.jceks"),
                     Paths.get("security/realm.properties"),
                     Paths.get("security/truststore")));
+
+    @BeforeClass
+    public void setup() {
+        IdentityServerTestUtils.initInstanceForTest();
+    }
 
     @BeforeMethod
     public void setupListAvailableUpdates() throws Exception {

--- a/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImplTest.java
+++ b/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImplTest.java
@@ -36,7 +36,7 @@ import org.assertj.core.api.Assertions;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;

--- a/openidm-repo-jdbc/pom.xml
+++ b/openidm-repo-jdbc/pom.xml
@@ -164,6 +164,14 @@
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openidm-repo-jdbc/src/test/java/org/forgerock/openidm/datasource/jdbc/impl/JDBCDataSourceServiceTest.java
+++ b/openidm-repo-jdbc/src/test/java/org/forgerock/openidm/datasource/jdbc/impl/JDBCDataSourceServiceTest.java
@@ -12,8 +12,15 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.datasource.jdbc.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.fieldIfNotNull;
+import static org.forgerock.json.JsonValue.object;
 
 import com.jolbox.bonecp.BoneCPDataSource;
 import com.zaxxer.hikari.HikariDataSource;
@@ -22,22 +29,21 @@ import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
 import javax.sql.DataSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import org.forgerock.json.JsonPointer;
-import static org.forgerock.json.JsonValue.object;
-import static org.forgerock.json.JsonValue.field;
-import static org.forgerock.json.JsonValue.fieldIfNotNull;
-
 import org.forgerock.json.JsonValue;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.datasource.DataSourceService;
-
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
  * Test of JDBCDataSourceServiceTest
  */
 public class JDBCDataSourceServiceTest {
+    @BeforeClass
+    public void setup() {
+        IdentityServerTestUtils.initInstanceForTest();
+    }
 
     @Test
     public void testHikariDataSource() {

--- a/openidm-repo-jdbc/src/test/java/org/forgerock/openidm/datasource/jdbc/impl/JDBCDataSourceServiceTest.java
+++ b/openidm-repo-jdbc/src/test/java/org/forgerock/openidm/datasource/jdbc/impl/JDBCDataSourceServiceTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import javax.sql.DataSource;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.datasource.DataSourceService;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/openidm-repo-orientdb/pom.xml
+++ b/openidm-repo-orientdb/pom.xml
@@ -168,6 +168,14 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openidm-repo-orientdb/src/test/java/org/forgerock/openidm/repo/orientdb/impl/EmbeddedOServerServiceTest.java
+++ b/openidm-repo-orientdb/src/test/java/org/forgerock/openidm/repo/orientdb/impl/EmbeddedOServerServiceTest.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orientechnologies.orient.server.plugin.OServerPlugin;
 import java.util.Map;
 import org.forgerock.json.JsonValue;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 

--- a/openidm-repo-orientdb/src/test/java/org/forgerock/openidm/repo/orientdb/impl/EmbeddedOServerServiceTest.java
+++ b/openidm-repo-orientdb/src/test/java/org/forgerock/openidm/repo/orientdb/impl/EmbeddedOServerServiceTest.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2014 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -21,18 +22,26 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
+
 package org.forgerock.openidm.repo.orientdb.impl;
 
+
+import static org.testng.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orientechnologies.orient.server.plugin.OServerPlugin;
 import java.util.Map;
 import org.forgerock.json.JsonValue;
-import org.testng.annotations.*;
-import static org.testng.Assert.*;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 
 public class EmbeddedOServerServiceTest {
-    
+    @BeforeTest
+    public void setup() {
+        IdentityServerTestUtils.initInstanceForTest();
+    }
+
     @AfterTest
     public void automaticBackupHandlerConfigTest() throws Exception {
         String automaticBackupConfig = "{"

--- a/openidm-security/pom.xml
+++ b/openidm-security/pom.xml
@@ -32,10 +32,6 @@
         This bundle exposes a simple service for managing JKS certificates and keys.
     </description>
 
-    <properties>
-        <powermock.version>1.7.1</powermock.version>
-    </properties>
-
     <dependencies>
         <!-- Wren:IDM dependencies -->
         <dependency>
@@ -123,20 +119,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/openidm-security/pom.xml
+++ b/openidm-security/pom.xml
@@ -32,6 +32,10 @@
         This bundle exposes a simple service for managing JKS certificates and keys.
     </description>
 
+    <properties>
+        <powermock.version>1.7.1</powermock.version>
+    </properties>
+
     <dependencies>
         <!-- Wren:IDM dependencies -->
         <dependency>
@@ -117,6 +121,26 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
             <scope>test</scope>
@@ -130,8 +154,10 @@
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/EntryResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/EntryResourceProviderTest.java
@@ -12,28 +12,31 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.security.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.resource.PatchOperation.add;
-import static org.forgerock.json.resource.Requests.*;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
+import static org.forgerock.json.resource.Requests.newActionRequest;
+import static org.forgerock.json.resource.Requests.newCreateRequest;
+import static org.forgerock.json.resource.Requests.newDeleteRequest;
+import static org.forgerock.json.resource.Requests.newPatchRequest;
+import static org.forgerock.json.resource.Requests.newReadRequest;
+import static org.forgerock.json.resource.Requests.newUpdateRequest;
 import static org.forgerock.openidm.security.impl.SecurityTestUtils.createKeyStores;
 import static org.forgerock.openidm.util.CertUtil.generateCertificate;
 import static org.mockito.Mockito.mock;
 
-import java.nio.file.Paths;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.json.JsonValue;
@@ -47,7 +50,7 @@ import org.forgerock.json.resource.QueryResponse;
 import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
-import org.forgerock.openidm.core.IdentityServer;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.CryptoService;
 import org.forgerock.openidm.crypto.KeyRepresentation;
 import org.forgerock.openidm.crypto.factory.CryptoServiceFactory;
@@ -73,15 +76,9 @@ public class EntryResourceProviderTest {
     @BeforeClass
     public void setUp() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        System.setProperty(LAUNCHER_PROJECT_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        System.setProperty(LAUNCHER_INSTALL_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        try {
-            IdentityServer.initInstance(null);
-        } catch (final IllegalStateException e) {
-            // tried to reinitialize ignore
-        }
+
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
+        IdentityServerTestUtils.verifyBootPropertiesLoaded();
     }
 
     @Test

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/EntryResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/EntryResourceProviderTest.java
@@ -50,7 +50,7 @@ import org.forgerock.json.resource.QueryResponse;
 import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.CryptoService;
 import org.forgerock.openidm.crypto.KeyRepresentation;
 import org.forgerock.openidm.crypto.factory.CryptoServiceFactory;

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/KeystoreResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/KeystoreResourceProviderTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.forgerock.openidm.security.impl;
@@ -20,19 +21,15 @@ import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.resource.test.assertj.AssertJActionResponseAssert.assertThat;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
 import static org.forgerock.openidm.security.impl.SecurityTestUtils.createKeyStores;
 import static org.mockito.Mockito.mock;
 
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.assertj.core.api.Assertions;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.json.JsonValue;
@@ -42,7 +39,7 @@ import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.test.assertj.AssertJActionResponseAssert;
 import org.forgerock.json.test.assertj.AssertJJsonValueAssert;
-import org.forgerock.openidm.core.IdentityServer;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.impl.CryptoServiceImpl;
 import org.forgerock.openidm.keystore.KeyStoreManagementService;
 import org.forgerock.openidm.keystore.KeyStoreService;
@@ -65,15 +62,9 @@ public class KeystoreResourceProviderTest {
     @BeforeClass
     public void runInitalSetup() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        System.setProperty(LAUNCHER_PROJECT_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        System.setProperty(LAUNCHER_INSTALL_LOCATION,
-                Paths.get(getClass().getResource("/").toURI()).toFile().getAbsolutePath());
-        try {
-            IdentityServer.initInstance(null);
-        } catch (final IllegalStateException e) {
-            // tried to reinitialize ignore
-        }
+
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
+        IdentityServerTestUtils.verifyBootPropertiesLoaded();
     }
 
     @Test

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/KeystoreResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/KeystoreResourceProviderTest.java
@@ -210,7 +210,9 @@ public class KeystoreResourceProviderTest {
     }
 
     private String replaceNewLines(final String string) {
-        return string.replaceAll("\n", "");
+        return string
+            .replaceAll("\r\n", "") // Windows Line Endings
+            .replaceAll("\n", "");  // Linux / Unix Line Endings
     }
 
     private String convertCertToPEM(final byte[] encodedCert) {

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/KeystoreResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/KeystoreResourceProviderTest.java
@@ -39,7 +39,7 @@ import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.test.assertj.AssertJActionResponseAssert;
 import org.forgerock.json.test.assertj.AssertJJsonValueAssert;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.impl.CryptoServiceImpl;
 import org.forgerock.openidm.keystore.KeyStoreManagementService;
 import org.forgerock.openidm.keystore.KeyStoreService;

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/PrivateKeyResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/PrivateKeyResourceProviderTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.mock;
 import org.forgerock.json.resource.NotSupportedException;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.impl.CryptoServiceImpl;
 import org.forgerock.openidm.keystore.KeyStoreManagementService;
 import org.forgerock.openidm.keystore.KeyStoreService;

--- a/openidm-security/src/test/java/org/forgerock/openidm/security/impl/PrivateKeyResourceProviderTest.java
+++ b/openidm-security/src/test/java/org/forgerock/openidm/security/impl/PrivateKeyResourceProviderTest.java
@@ -12,7 +12,9 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.security.impl;
 
 import static org.forgerock.json.resource.Requests.newReadRequest;
@@ -22,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import org.forgerock.json.resource.NotSupportedException;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.openidm.crypto.impl.CryptoServiceImpl;
 import org.forgerock.openidm.keystore.KeyStoreManagementService;
 import org.forgerock.openidm.keystore.KeyStoreService;
@@ -29,11 +32,18 @@ import org.forgerock.openidm.keystore.impl.KeyStoreServiceImpl;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.test.assertj.AssertJPromiseAssert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class PrivateKeyResourceProviderTest {
 
     private static final String TEST_KEY_ALIAS = "testCert";
+
+    @BeforeClass
+    public void runInitalSetup() throws Exception {
+        IdentityServerTestUtils.initInstanceForTest(this.getClass());
+        IdentityServerTestUtils.verifyBootPropertiesLoaded();
+    }
 
     @Test
     public void testReadPrivateKey() throws Exception {

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
@@ -160,8 +160,8 @@ public class SelfService implements IdentityProviderListener {
             synchronized (SelfService.class) {
                 // Double-checked locking pattern
                 if (sharedKeyAlias == null) {
-                    sharedKeyAlias =
-                        IdentityServer
+                    sharedKeyAlias
+                        = IdentityServer
                             .getInstance()
                             .getProperty(SHARED_KEY_PROPERTY, DEFAULT_SHARED_KEY_ALIAS);
                 }

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
@@ -12,7 +12,9 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
+
 package org.forgerock.openidm.selfservice.impl;
 
 import static org.forgerock.http.handler.HttpClientHandler.OPTION_LOADER;
@@ -99,8 +101,7 @@ public class SelfService implements IdentityProviderListener {
     private static final String DEFAULT_SHARED_KEY_ALIAS = "openidm-selfservice-key";
 
     /** the shared key alias */
-    private static final String SHARED_KEY_ALIAS =
-            IdentityServer.getInstance().getProperty(SHARED_KEY_PROPERTY, DEFAULT_SHARED_KEY_ALIAS);
+    private static volatile String sharedKeyAlias;
 
     /** the registered parent router-path for self-service flows */
     static final String ROUTER_PREFIX = "selfservice";
@@ -144,6 +145,31 @@ public class SelfService implements IdentityProviderListener {
     private ServiceRegistration<RequestHandler> serviceRegistration = null;
     private ComponentContext context;
     private ProgressStageProvider progressStageProvider;
+
+    /**
+     * Get the alias of the key self-service uses for pre-shared key encryption.
+     *
+     * <p>The alias is read from the identity server configuration only once, and then cached
+     * statically.
+     *
+     * @return
+     *   The key alias.
+     */
+    public static String getSharedKeyAlias() {
+        if (sharedKeyAlias == null) {
+            synchronized (SelfService.class) {
+                // Double-checked locking pattern
+                if (sharedKeyAlias == null) {
+                    sharedKeyAlias =
+                        IdentityServer
+                            .getInstance()
+                            .getProperty(SHARED_KEY_PROPERTY, DEFAULT_SHARED_KEY_ALIAS);
+                }
+            }
+        }
+
+        return sharedKeyAlias;
+    }
 
     @Activate
     void activate(ComponentContext context) throws Exception {
@@ -271,7 +297,7 @@ public class SelfService implements IdentityProviderListener {
     private JwtTokenHandler createJwtTokenHandler(final JwtTokenHandlerConfig jwtTokenHandlerConfig) {
         try {
             // pull the shared key in from the keystore
-            final Key key = sharedKeyService.getSharedKey(SHARED_KEY_ALIAS);
+            final Key key = sharedKeyService.getSharedKey(getSharedKeyAlias());
             final String sharedKey = Base64.encode(key.getEncoded());
             final SigningHandler signingHandler = new SigningManager().newHmacSigningHandler(sharedKey.getBytes());
 

--- a/openidm-shell/src/main/java/org/forgerock/openidm/shell/impl/Main.java
+++ b/openidm-shell/src/main/java/org/forgerock/openidm/shell/impl/Main.java
@@ -49,6 +49,9 @@ public final class Main {
     public static void main(String[] args) throws Exception {
         initProcessor();
         CommandSession session = processor.createSession(System.in, System.out, System.err);
+
+        IdentityServer.initInstance(null);
+
         session.put("prompt", "openidm# ");
         session.put("_cwd", IdentityServer.getFileForPath("."));
 

--- a/openidm-system/pom.xml
+++ b/openidm-system/pom.xml
@@ -33,10 +33,6 @@
         system.
     </description>
 
-    <properties>
-        <powermock.version>1.7.1</powermock.version>
-    </properties>
-
     <dependencies>
         <!-- Provided OSGi Dependencies -->
         <dependency>
@@ -72,20 +68,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openidm-system/pom.xml
+++ b/openidm-system/pom.xml
@@ -33,6 +33,10 @@
         system.
     </description>
 
+    <properties>
+        <powermock.version>1.7.1</powermock.version>
+    </properties>
+
     <dependencies>
         <!-- Provided OSGi Dependencies -->
         <dependency>
@@ -68,6 +72,20 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openidm-system/pom.xml
+++ b/openidm-system/pom.xml
@@ -177,6 +177,19 @@
                     </instructions>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
@@ -80,11 +80,10 @@ public final class IdentityServer implements PropertyAccessor {
      * of the provided set of properties.
      *
      * @param properties
-     *            The properties to use when initializing this environment
-     *            configuration, or {@code null} to use an empty set of
-     *            properties.
+     *   The properties to use when initializing this environment configuration, or {@code null} to
+     *   use an empty set of properties.
      */
-    private IdentityServer(PropertyAccessor properties) {
+    /* default */ IdentityServer(PropertyAccessor properties) {
         configProperties = properties;
 
         String bootFileName
@@ -95,30 +94,58 @@ public final class IdentityServer implements PropertyAccessor {
         bootFileProperties = loadProps(bootFileName);
     }
 
+    /**
+     * Get the current {@code IdentityServer} singleton instance.
+     *
+     * <p>The server must have been initialized before this method can be called. Calling it before
+     * the server is initialized yields an {@link IllegalStateException}.
+     *
+     * @see #initInstance(IdentityServer)
+     * @see #initInstance(PropertyAccessor)
+     *
+     * @return
+     *   The current, singleton {@code IdentityServer} instance.
+     *
+     * @throws IllegalStateException
+     *   If the server has not yet been initialized.
+     */
     public static IdentityServer getInstance() {
-        if (IDENTITY_SERVER == null) {
+        if (!isInitialized()) {
             throw new IllegalStateException("IdentityServer has not been initialised");
         }
+
         return IDENTITY_SERVER;
     }
 
     /**
-     * Initialise the singleton {@link IdentityServer} instance with the
+     * Get whether or not the {@code IdentityServer} has been initialized.
+     *
+     * @return
+     *   {@code true} if the server has been initialized; or, {@code false} if it has not been
+     *   initialized.
+     */
+    public static boolean isInitialized() {
+        return (IDENTITY_SERVER != null);
+    }
+
+    /**
+     * Initialize the singleton {@code IdentityServer} instance with the
      * provided {@link PropertyAccessor} instance.
      * <p>
      * This and the {@link #initInstance(IdentityServer)} method can be called
      * only once. Subsequent calls will result in a {@link IllegalStateException}.
      *
-     * @param   properties
-     *          The parent {@code PropertyAccessor}.
+     * @param properties
+     *   The parent {@code PropertyAccessor}.
      *
-     * @return  New instance of {@link IdentityServer}.
+     * @return
+     *   New instance of {@link IdentityServer}.
      *
-     * @throws  IllegalStateException
-     *          If this method is called more then once.
+     * @throws IllegalStateException
+     *   If this method is called more then once.
      */
     public static synchronized IdentityServer initInstance(PropertyAccessor properties) {
-        if (IDENTITY_SERVER == null) {
+        if (!isInitialized()) {
             final IdentityServer newInstance;
 
             if (properties instanceof IdentityServer) {
@@ -136,24 +163,25 @@ public final class IdentityServer implements PropertyAccessor {
     }
 
     /**
-     * Initialise the singleton {@link IdentityServer} instance with the
+     * Initialize the singleton {@code IdentityServer} instance with the
      * provided {@link IdentityServer} instance, or the default instance.
-     * <p>
-     * This and the {@link #initInstance(PropertyAccessor)} method can be called
-     * only once. Subsequent calls will result in a {@link IllegalStateException}.
      *
-     * @param   server
-     *          New instance of {@link IdentityServer}. Can be {@code null} to generate a default
-     *          instance that uses only system properties.
+     * <p>This and the {@link #initInstance(PropertyAccessor)} method can be called only once.
+     * Subsequent calls will result in a {@link IllegalStateException}.
      *
-     * @return  Same instance as the {@code server} parameter, if not {@code null}; otherwise, the
-     *          new {@link IdentityServer instance}.
+     * @param server
+     *   New instance of {@link IdentityServer}. Can be {@code null} to generate a default instance
+     *   that uses only system properties.
      *
-     * @throws  IllegalStateException
-     *          If this method is called more then once.
+     * @return
+     *   Same instance as the {@code server} parameter, if not {@code null}; otherwise, the new
+     *   {@link IdentityServer instance}.
+     *
+     * @throws IllegalStateException
+     *   If this method is called more then once.
      */
     public static synchronized IdentityServer initInstance(final IdentityServer server) {
-        if (IDENTITY_SERVER == null) {
+        if (!isInitialized()) {
             final IdentityServer newInstance;
 
             if (server != null) {
@@ -171,7 +199,19 @@ public final class IdentityServer implements PropertyAccessor {
     }
 
     /**
-     * Retrieves the property value by looking in System properties, boot properties, and then config properties.
+     * Clear the singleton {@code IdentityServer} instance so that the identity server can be
+     * initialized again.
+     *
+     * <p>This method is intended only for use internally by the identity server and tests. There
+     * is typically no good reason to call this method in a production environment.
+     */
+    /* default */ static synchronized void clearInstance() {
+        IDENTITY_SERVER = null;
+    }
+
+    /**
+     * Retrieves the property value by looking in System properties, boot properties, and then
+     * config properties.
      *
      * @param key The name of the requested property.
      * @param defaultValue the value returned if not found in the propertyAccessors.
@@ -183,8 +223,10 @@ public final class IdentityServer implements PropertyAccessor {
     public <T> T getProperty(String key, T defaultValue, Class<T> expected) {
         // First check System properties for our value.
         T value = systemPropertyAccessor.getProperty(key, null, expected);
+
         if (null == value) {
-            // Not found in system properties, now check the boot file, if the property is expected to be a String.
+            // Not found in system properties, now check the boot file, if the property is expected
+            // to be a String.
             boolean expectsString = ((null != expected && expected.isAssignableFrom(String.class))
                     || defaultValue instanceof String);
 
@@ -435,6 +477,16 @@ public final class IdentityServer implements PropertyAccessor {
             // path, serverRoot);
             return new File(rootLocation, path).getAbsoluteFile();
         }
+    }
+
+    /**
+     * Get the file (if any) from which boot properties were loaded.
+     *
+     * @return
+     *   The boot properties file.
+     */
+    public File getBootPropertyFile() {
+        return bootPropertyFile;
     }
 
     public File getInstallLocation() {

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
@@ -38,7 +38,6 @@ import java.util.Properties;
  * @version $Revision$ $Date$
  */
 public final class IdentityServer implements PropertyAccessor {
-
     /**
      * The singleton Identity Server instance.
      */
@@ -88,8 +87,8 @@ public final class IdentityServer implements PropertyAccessor {
     private IdentityServer(PropertyAccessor properties) {
         configProperties = properties;
 
-        String bootFileName =
-            getProperty(
+        String bootFileName
+            = getProperty(
                 ServerConstants.PROPERTY_BOOT_FILE_LOCATION,
                 ServerConstants.DEFAULT_BOOT_FILE_LOCATION);
 
@@ -157,7 +156,7 @@ public final class IdentityServer implements PropertyAccessor {
         if (IDENTITY_SERVER == null) {
             final IdentityServer newInstance;
 
-            if (server != null ) {
+            if (server != null) {
                 newInstance = server;
             } else {
                 newInstance = new IdentityServer(null);

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
@@ -42,7 +42,7 @@ public final class IdentityServer implements PropertyAccessor {
     /**
      * The singleton Identity Server instance.
      */
-    private static volatile IdentityServer IDENTITY_SERVER = null;
+    private static volatile IdentityServer IDENTITY_SERVER;
 
     /**
      * The various defined boot properties.

--- a/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTest.java
+++ b/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTest.java
@@ -29,8 +29,8 @@ import java.io.File;
 import java.net.URLDecoder;
 import java.util.Properties;
 import org.forgerock.json.JsonValue;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -61,188 +61,125 @@ public class IdentityServerTest {
         assertThat(new File(bootFile).canRead()).isTrue();
 
         System.setProperty(ServerConstants.PROPERTY_BOOT_FILE_LOCATION, bootFile);
+    }
+
+    @BeforeMethod
+    public void initTestServer() {
+        ensureServerNotInitialized();
         IdentityServer.initInstance(new TestPropertyAccessor());
     }
 
     @Test
     public void testInitInstanceWithPropertiesWhenNotInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerNotInitialized();
 
-        try {
-            ensureServerNotInitialized();
+        final IdentityServer returnedInstance
+            = IdentityServer.initInstance(new TestPropertyAccessor());
 
-            final IdentityServer returnedInstance
-                = IdentityServer.initInstance(new TestPropertyAccessor());
+        assertThat(returnedInstance).isNotNull();
+        assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
 
-            assertThat(returnedInstance).isNotNull();
-            assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
-
-            // This value only exists when we are using the test property accessor
-            assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY))
-                .isEqualTo(FAKE_PROPERTY_VALUE);
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
-        }
+        // This value only exists when we are using the test property accessor
+        assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY))
+            .isEqualTo(FAKE_PROPERTY_VALUE);
     }
 
     @Test
     public void testInitInstanceWithPropertiesWhenAlreadyInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerInitialized();
 
         try {
-            ensureServerInitialized();
+            IdentityServer.initInstance(new TestPropertyAccessor());
 
-            try {
-                IdentityServer.initInstance(new TestPropertyAccessor());
-
-                fail("Expected an IllegalStateException for attempting to initialize twice");
-            }
-            catch (IllegalStateException expected) {
-                // Expected exception
-            }
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
+            fail("Expected an IllegalStateException for attempting to initialize twice");
+        } catch (IllegalStateException expected) {
+            // Expected exception
         }
     }
 
     @Test
     public void testInitInstanceWithPropertiesWhenGivenNullAndNotInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerNotInitialized();
 
-        try {
-            ensureServerNotInitialized();
+        final IdentityServer returnedInstance
+            = IdentityServer.initInstance((PropertyAccessor)null);
 
-            final IdentityServer returnedInstance
-                = IdentityServer.initInstance((PropertyAccessor)null);
+        assertThat(returnedInstance).isNotNull();
+        assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
 
-            assertThat(returnedInstance).isNotNull();
-            assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
-
-            // This value only exists when we are using the test property accessor
-            assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY)).isNull();
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
-        }
+        // This value only exists when we are using the test property accessor
+        assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY)).isNull();
     }
 
     @Test
     public void testInitInstanceWithPropertiesWhenGivenNullAndAlreadyInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerInitialized();
 
         try {
-            ensureServerInitialized();
+            IdentityServer.initInstance((PropertyAccessor)null);
 
-            try {
-                IdentityServer.initInstance((PropertyAccessor)null);
-
-                fail("Expected an IllegalStateException for attempting to initialize twice");
-            }
-            catch (IllegalStateException expected) {
-                // Expected exception
-            }
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
+            fail("Expected an IllegalStateException for attempting to initialize twice");
+        } catch (IllegalStateException expected) {
+            // Expected exception
         }
     }
 
     @Test
     public void testInitInstanceWithServerWhenNotInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerNotInitialized();
 
-        try {
-            ensureServerNotInitialized();
+        final IdentityServer newInstance = IdentityServerTestUtils.createServerInstance();
+        final IdentityServer returnedInstance = IdentityServer.initInstance(newInstance);
 
-            final IdentityServer newInstance = IdentityServerTestUtils.createServerInstance();
-            final IdentityServer returnedInstance = IdentityServer.initInstance(newInstance);
+        assertThat(returnedInstance).isNotNull();
+        assertThat(newInstance).isEqualTo(returnedInstance);
+        assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
 
-            assertThat(returnedInstance).isNotNull();
-            assertThat(newInstance).isEqualTo(returnedInstance);
-            assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
-
-            // This value only exists when we are using the test property accessor
-            assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY)).isNull();
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
-        }
+        // This value only exists when we are using the test property accessor
+        assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY)).isNull();
     }
 
     @Test
     public void testInitInstanceWithServerWhenAlreadyInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerInitialized();
+
+        final IdentityServer newInstance = IdentityServerTestUtils.createServerInstance();
 
         try {
-            ensureServerInitialized();
+            IdentityServer.initInstance(newInstance);
 
-            final IdentityServer newInstance = IdentityServerTestUtils.createServerInstance();
-
-            try {
-                IdentityServer.initInstance(newInstance);
-
-                fail("Expected an IllegalStateException for attempting to initialize twice");
-            }
-            catch (IllegalStateException expected) {
-                // Expected exception
-            }
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
+            fail("Expected an IllegalStateException for attempting to initialize twice");
+        } catch (IllegalStateException expected) {
+            // Expected exception
         }
     }
 
     @Test
     @SuppressWarnings("RedundantCast")
     public void testInitInstanceWithServerWhenGivenNullAndNotInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerNotInitialized();
 
-        try {
-            ensureServerNotInitialized();
+        final IdentityServer returnedInstance
+            = IdentityServer.initInstance((IdentityServer)null);
 
-            final IdentityServer returnedInstance
-                = IdentityServer.initInstance((IdentityServer)null);
+        assertThat(returnedInstance).isNotNull();
+        assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
 
-            assertThat(returnedInstance).isNotNull();
-            assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
-
-            // This value only exists when we are using the test property accessor
-            assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY)).isNull();
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
-        }
+        // This value only exists when we are using the test property accessor
+        assertThat(returnedInstance.getProperty(FAKE_PROPERTY_KEY)).isNull();
     }
 
     @Test
     @SuppressWarnings("RedundantCast")
     public void testInitInstanceWithServerWhenGivenNullAndAlreadyInitialized() {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        ensureServerInitialized();
 
         try {
-            ensureServerInitialized();
+            IdentityServer.initInstance((IdentityServer)null);
 
-            try {
-                IdentityServer.initInstance((IdentityServer)null);
-
-                fail("Expected an IllegalStateException for attempting to initialize twice");
-            }
-            catch (IllegalStateException expected) {
-                // Expected exception
-            }
-        }
-        finally {
-            // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
+            fail("Expected an IllegalStateException for attempting to initialize twice");
+        } catch (IllegalStateException expected) {
+            // Expected exception
         }
     }
 
@@ -265,8 +202,8 @@ public class IdentityServerTest {
     }
 
     /**
-     * Since we can't unset the property in the boot file, we need to test that System can override Config on a property
-     * not in the boot file.
+     * Since we can't unset the property in the boot file, we need to test that System can override
+     * Config on a property not in the boot file.
      */
     @Test
     public void testSystemOverridesConfig() {
@@ -304,14 +241,16 @@ public class IdentityServerTest {
 
     private void ensureServerNotInitialized() {
         IdentityServerTestUtils.clearServerInitialization();
-        assertThat(IdentityServerTestUtils.getServerInstance()).isNull();
+
+        assertThat(IdentityServer.isInitialized()).isFalse();
     }
 
     private void ensureServerInitialized() {
-        IdentityServerTestUtils.setServerInstance(
-            IdentityServerTestUtils.createServerInstance());
+        if (!IdentityServer.isInitialized()) {
+            IdentityServer.initInstance(IdentityServerTestUtils.createServerInstance());
+        }
 
-        assertThat(IdentityServerTestUtils.getServerInstance()).isNotNull();
+        assertThat(IdentityServer.isInitialized()).isTrue();
     }
 
     private static class TestPropertyAccessor implements PropertyAccessor {

--- a/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTest.java
+++ b/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTest.java
@@ -71,8 +71,8 @@ public class IdentityServerTest {
         try {
             ensureServerNotInitialized();
 
-            final IdentityServer returnedInstance =
-                IdentityServer.initInstance(new TestPropertyAccessor());
+            final IdentityServer returnedInstance
+                = IdentityServer.initInstance(new TestPropertyAccessor());
 
             assertThat(returnedInstance).isNotNull();
             assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
@@ -116,8 +116,8 @@ public class IdentityServerTest {
         try {
             ensureServerNotInitialized();
 
-            final IdentityServer returnedInstance =
-                IdentityServer.initInstance((PropertyAccessor)null);
+            final IdentityServer returnedInstance
+                = IdentityServer.initInstance((PropertyAccessor)null);
 
             assertThat(returnedInstance).isNotNull();
             assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);
@@ -160,7 +160,7 @@ public class IdentityServerTest {
         try {
             ensureServerNotInitialized();
 
-            final IdentityServer newInstance      = IdentityServerTestUtils.createServerInstance();
+            final IdentityServer newInstance = IdentityServerTestUtils.createServerInstance();
             final IdentityServer returnedInstance = IdentityServer.initInstance(newInstance);
 
             assertThat(returnedInstance).isNotNull();
@@ -208,8 +208,8 @@ public class IdentityServerTest {
         try {
             ensureServerNotInitialized();
 
-            final IdentityServer returnedInstance =
-                IdentityServer.initInstance((IdentityServer)null);
+            final IdentityServer returnedInstance
+                = IdentityServer.initInstance((IdentityServer)null);
 
             assertThat(returnedInstance).isNotNull();
             assertThat(IdentityServer.getInstance()).isEqualTo(returnedInstance);

--- a/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTestUtils.java
+++ b/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTestUtils.java
@@ -14,7 +14,7 @@
  * Copyright 2018 Wren Security.
  */
 
-package org.forgerock.openidm.core.util;
+package org.forgerock.openidm.core;
 
 import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
 import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
@@ -23,9 +23,6 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.forgerock.openidm.core.IdentityServer;
-import org.forgerock.openidm.core.PropertyAccessor;
-import org.powermock.reflect.Whitebox;
 
 /**
  * A utility class for tests that depend on the state of
@@ -122,8 +119,7 @@ public final class IdentityServerTestUtils {
      * file.
      */
     public static void verifyBootPropertiesLoaded() {
-        final File bootPropertyFile
-            = Whitebox.getInternalState(IdentityServer.getInstance(), "bootPropertyFile");
+        final File bootPropertyFile = IdentityServer.getInstance().getBootPropertyFile();
 
         if ((bootPropertyFile == null) || !bootPropertyFile.canRead()) {
             throw new IllegalStateException(
@@ -132,39 +128,8 @@ public final class IdentityServerTestUtils {
     }
 
     /**
-     * Uses reflection to obtain the current {@code IdentityServer} instance that is in use at this
-     * exact moment.
-     *
-     * <p>This should only be used to capture the server instance before temporarily manipulating it
-     * in a test. All other use cases should be using {@link IdentityServer#getInstance()}.
-     *
-     * @see #setServerInstance(IdentityServer)
-     *
-     * @return
-     *  The current identity server instance. May be {@code null}, if the server has not yet been
-     *  initialized.
-     */
-    public static IdentityServer getServerInstance() {
-        return Whitebox.getInternalState(IdentityServer.class, IDENTITY_SERVER_FIELD);
-    }
-
-    /**
-     * Uses reflection to set the current {@code IdentityServer} instance to use from this moment
-     * forward.
-     *
-     * <p>This should only be used to temporarily manipulate server instances during a single test.
-     * Be sure to reset the value to its original value at the end of the test! All other use cases
-     * should be using {@link IdentityServer#getInstance()}.
-     *
-     * @see #getServerInstance()
-     */
-    public static void setServerInstance(final IdentityServer server) {
-        Whitebox.setInternalState(IdentityServer.class, IDENTITY_SERVER_FIELD, server);
-    }
-
-    /**
-     * Uses reflection to create a new instance of the {@code IdentityServer} that is initialized
-     * without any properties.
+     * Creates a new instance of the {@code IdentityServer} that is initialized without any
+     * properties.
      *
      * <p>This should only be used by tests that are trying to verify two instances are different.
      *
@@ -172,33 +137,16 @@ public final class IdentityServerTestUtils {
      *   A new identity server instance.
      */
     public static IdentityServer createServerInstance() {
-        final IdentityServer instance;
-
-        try {
-            instance
-                = Whitebox.invokeConstructor(
-                    IdentityServer.class,
-                    new Class[]  { PropertyAccessor.class },
-                    new Object[] { null                   });
-        } catch (Exception ex) {
-            throw new RuntimeException(
-                "Failed to instantiate a IdentityServer instance.", ex);
-        }
-
-        return instance;
+        return new IdentityServer(null);
     }
 
     /**
      * Resets the {@code IdentityServer} to its initial state -- without any server instance.
      *
      * <p>This should only be used to temporarily manipulate server instances during a single test.
-     * Be sure to reset the value to its original value at the end of the test!
-     *
-     * @see #getServerInstance()
-     * @see #setServerInstance(IdentityServer)
      */
     public static void clearServerInitialization() {
-        setServerInstance(null);
+        IdentityServer.clearInstance();
     }
 
     /**

--- a/openidm-system/src/test/java/org/forgerock/openidm/core/util/IdentityServerTestUtils.java
+++ b/openidm-system/src/test/java/org/forgerock/openidm/core/util/IdentityServerTestUtils.java
@@ -107,8 +107,7 @@ public final class IdentityServerTestUtils {
      *   If the server was already initialized with a different project or install location than
      *   what has been provided.
      */
-    public static void initInstanceForTest(final String projectLocation,
-                                           final String installLocation)
+    public static void initInstanceForTest(final String projectLocation, final String installLocation)
     throws IllegalStateException {
         System.setProperty(LAUNCHER_PROJECT_LOCATION, projectLocation);
         System.setProperty(LAUNCHER_INSTALL_LOCATION, installLocation);
@@ -123,8 +122,8 @@ public final class IdentityServerTestUtils {
      * file.
      */
     public static void verifyBootPropertiesLoaded() {
-        final File bootPropertyFile =
-            Whitebox.getInternalState(IdentityServer.getInstance(), "bootPropertyFile");
+        final File bootPropertyFile
+            = Whitebox.getInternalState(IdentityServer.getInstance(), "bootPropertyFile");
 
         if ((bootPropertyFile == null) || !bootPropertyFile.canRead()) {
             throw new IllegalStateException(
@@ -176,8 +175,8 @@ public final class IdentityServerTestUtils {
         final IdentityServer instance;
 
         try {
-            instance =
-                Whitebox.invokeConstructor(
+            instance
+                = Whitebox.invokeConstructor(
                     IdentityServer.class,
                     new Class[]  { PropertyAccessor.class },
                     new Object[] { null                   });
@@ -198,7 +197,6 @@ public final class IdentityServerTestUtils {
      * @see #getServerInstance()
      * @see #setServerInstance(IdentityServer)
      */
-    @SuppressWarnings("RedundantCast")
     public static void clearServerInitialization() {
         setServerInstance(null);
     }
@@ -220,8 +218,7 @@ public final class IdentityServerTestUtils {
      *   If the server was already initialized with a different project or install location than
      *   what has been provided.
      */
-    public static void verifyServerInitPaths(final String projectLocation,
-                                              final String installLocation)
+    public static void verifyServerInitPaths(final String projectLocation, final String installLocation)
     throws IllegalStateException {
         final IdentityServer server = IdentityServer.getInstance();
         final String initializedProjectLocation = server.getProjectLocation().getAbsolutePath();

--- a/openidm-system/src/test/java/org/forgerock/openidm/core/util/IdentityServerTestUtils.java
+++ b/openidm-system/src/test/java/org/forgerock/openidm/core/util/IdentityServerTestUtils.java
@@ -1,0 +1,245 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2018 Wren Security.
+ */
+
+package org.forgerock.openidm.core.util;
+
+import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
+import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.forgerock.openidm.core.IdentityServer;
+import org.forgerock.openidm.core.PropertyAccessor;
+import org.powermock.reflect.Whitebox;
+
+/**
+ * A utility class for tests that depend on the state of
+ * {@code org.forgerock.openidm.coreIdentityServer} to function.
+ */
+public final class IdentityServerTestUtils {
+    /**
+     * The name of the field in {@code IdentityServer} that contains the current server instance.
+     */
+    public static final String IDENTITY_SERVER_FIELD = "IDENTITY_SERVER";
+
+    /**
+     * Private constructor for utility class.
+     */
+    private IdentityServerTestUtils() {
+    }
+
+    /**
+     * Attempts to initialize the global {@code IdentityServer} instance for the current test.
+     *
+     * <p>If the server is already initialized, no exception is thrown.
+     *
+     * <p>This should be called only once per test, typically in a method annotated with
+     * {@link org.testng.annotations.BeforeClass} or {@link org.testng.annotations.BeforeTest}.
+     */
+    @SuppressWarnings("RedundantCast")
+    public static void initInstanceForTest() {
+        try {
+            IdentityServer.initInstance((IdentityServer)null);
+        } catch (final IllegalStateException e) {
+            // tried to reinitialize; ignore
+        }
+    }
+
+    /**
+     * Attempts to initialize the global {@code IdentityServer} instance to use the root of the
+     * test classpath as the project location ({@code launcher.project.location} and install
+     * location ({@code launcher.install.location} properties.
+     *
+     * <p>This should be called only once per test, typically in a method annotated with
+     * {@link org.testng.annotations.BeforeClass} or {@link org.testng.annotations.BeforeTest}.
+     *
+     * @param testClass
+     *   The class containing the tests being run.
+     *
+     * @throws IllegalStateException
+     *   If the server was already initialized with different paths for the project and/or
+     *   IDM install folder than the root of the test classpath.
+     */
+    public static void initInstanceForTest(Class<?> testClass) {
+        final Path classpathRoot;
+        final String classpathRootAbsolute;
+
+        try {
+            classpathRoot = Paths.get(testClass.getClass().getResource("/").toURI());
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException("Failed to parse classpath", ex);
+        }
+
+        classpathRootAbsolute = classpathRoot.toFile().getAbsolutePath();
+
+        initInstanceForTest(classpathRootAbsolute, classpathRootAbsolute);
+    }
+
+    /**
+     * Attempts to initialize the global {@code IdentityServer} instance to use the specified
+     * absolute paths for the project location ({@code launcher.project.location} and install
+     * location ({@code launcher.install.location} properties.
+     *
+     * <p>This should be called only once per test, typically in a method annotated with
+     * {@link org.testng.annotations.BeforeClass} or {@link org.testng.annotations.BeforeTest}.
+     *
+     * @param projectLocation
+     *   The absolute path to the folder that should be used as the project location.
+     * @param installLocation
+     *   The absolute path to the folder that should be used as the IDM install location.
+     *
+     * @throws IllegalStateException
+     *   If the server was already initialized with a different project or install location than
+     *   what has been provided.
+     */
+    public static void initInstanceForTest(final String projectLocation,
+                                           final String installLocation)
+    throws IllegalStateException {
+        System.setProperty(LAUNCHER_PROJECT_LOCATION, projectLocation);
+        System.setProperty(LAUNCHER_INSTALL_LOCATION, installLocation);
+
+        initInstanceForTest();
+
+        verifyServerInitPaths(projectLocation, installLocation);
+    }
+
+    /**
+     * Ensures that the {@code IdentityServer} has been initialized with a readable boot properties
+     * file.
+     */
+    public static void verifyBootPropertiesLoaded() {
+        final File bootPropertyFile =
+            Whitebox.getInternalState(IdentityServer.getInstance(), "bootPropertyFile");
+
+        if ((bootPropertyFile == null) || !bootPropertyFile.canRead()) {
+            throw new IllegalStateException(
+                "No boot properties file was loaded, but one is required for this test.");
+        }
+    }
+
+    /**
+     * Uses reflection to obtain the current {@code IdentityServer} instance that is in use at this
+     * exact moment.
+     *
+     * <p>This should only be used to capture the server instance before temporarily manipulating it
+     * in a test. All other use cases should be using {@link IdentityServer#getInstance()}.
+     *
+     * @see #setServerInstance(IdentityServer)
+     *
+     * @return
+     *  The current identity server instance. May be {@code null}, if the server has not yet been
+     *  initialized.
+     */
+    public static IdentityServer getServerInstance() {
+        return Whitebox.getInternalState(IdentityServer.class, IDENTITY_SERVER_FIELD);
+    }
+
+    /**
+     * Uses reflection to set the current {@code IdentityServer} instance to use from this moment
+     * forward.
+     *
+     * <p>This should only be used to temporarily manipulate server instances during a single test.
+     * Be sure to reset the value to its original value at the end of the test! All other use cases
+     * should be using {@link IdentityServer#getInstance()}.
+     *
+     * @see #getServerInstance()
+     */
+    public static void setServerInstance(final IdentityServer server) {
+        Whitebox.setInternalState(IdentityServer.class, IDENTITY_SERVER_FIELD, server);
+    }
+
+    /**
+     * Uses reflection to create a new instance of the {@code IdentityServer} that is initialized
+     * without any properties.
+     *
+     * <p>This should only be used by tests that are trying to verify two instances are different.
+     *
+     * @return
+     *   A new identity server instance.
+     */
+    public static IdentityServer createServerInstance() {
+        final IdentityServer instance;
+
+        try {
+            instance =
+                Whitebox.invokeConstructor(
+                    IdentityServer.class,
+                    new Class[]  { PropertyAccessor.class },
+                    new Object[] { null                   });
+        } catch (Exception ex) {
+            throw new RuntimeException(
+                "Failed to instantiate a IdentityServer instance.", ex);
+        }
+
+        return instance;
+    }
+
+    /**
+     * Resets the {@code IdentityServer} to its initial state -- without any server instance.
+     *
+     * <p>This should only be used to temporarily manipulate server instances during a single test.
+     * Be sure to reset the value to its original value at the end of the test!
+     *
+     * @see #getServerInstance()
+     * @see #setServerInstance(IdentityServer)
+     */
+    @SuppressWarnings("RedundantCast")
+    public static void clearServerInitialization() {
+        setServerInstance(null);
+    }
+
+    /**
+     * Verifies that the {@code IdentityServer} was initialized with the specified project and
+     * install locations.
+     *
+     * <p>This is used as a precaution to detect consistency issues in tests. Unfortunately, the
+     * identity server cannot be reinitialized again once it's been initialized, so it
+     * is conceivable that one set of tests could bash the state for subsequent tests.
+     *
+     * @param projectLocation
+     *   The absolute path to the folder that the server should be using for the project location.
+     * @param installLocation
+     *   The absolute path to the folder that the server should be using for the install location.
+     *
+     * @throws IllegalStateException
+     *   If the server was already initialized with a different project or install location than
+     *   what has been provided.
+     */
+    public static void verifyServerInitPaths(final String projectLocation,
+                                              final String installLocation)
+    throws IllegalStateException {
+        final IdentityServer server = IdentityServer.getInstance();
+        final String initializedProjectLocation = server.getProjectLocation().getAbsolutePath();
+
+        if (!initializedProjectLocation.equals(projectLocation)) {
+            throw new IllegalStateException(
+                String.format(
+                    "Server already initialized with a different project path (initialized with "
+                    + "'%s' but wanted '%s')", initializedProjectLocation, projectLocation));
+        }
+
+        final String initializedInstallLocation = server.getInstallLocation().getAbsolutePath();
+
+        if (!initializedInstallLocation.equals(installLocation)) {
+            throw new IllegalStateException(
+                String.format(
+                    "Server already initialized with a different install path (initialized with "
+                    + "'%s' but wanted '%s')", initializedInstallLocation, installLocation));
+        }
+    }
+}

--- a/openidm-util/pom.xml
+++ b/openidm-util/pom.xml
@@ -42,6 +42,8 @@
 
     <properties>
         <openidm.osgi.import.defaults>org.eclipse.wst.jsdt.debug.rhino.debugger;resolution:=optional</openidm.osgi.import.defaults>
+
+        <powermock.version>1.7.1</powermock.version>
     </properties>
 
     <dependencies>
@@ -161,8 +163,30 @@
         </dependency>
 
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.openidm</groupId>
+            <artifactId>openidm-system</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openidm-util/pom.xml
+++ b/openidm-util/pom.xml
@@ -42,8 +42,6 @@
 
     <properties>
         <openidm.osgi.import.defaults>org.eclipse.wst.jsdt.debug.rhino.debugger;resolution:=optional</openidm.osgi.import.defaults>
-
-        <powermock.version>1.7.1</powermock.version>
     </properties>
 
     <dependencies>
@@ -159,20 +157,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/openidm-util/src/test/java/org/forgerock/openidm/audit/util/RouterActivityLoggerTest.java
+++ b/openidm-util/src/test/java/org/forgerock/openidm/audit/util/RouterActivityLoggerTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.forgerock.openidm.audit.util;
@@ -40,6 +41,7 @@ import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.Responses;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.PropertyAccessor;
+import org.forgerock.openidm.core.util.IdentityServerTestUtils;
 import org.forgerock.services.TransactionId;
 import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
@@ -65,7 +67,8 @@ public class RouterActivityLoggerTest {
     private JsonValue after;
 
     @BeforeClass
-    public void setup() throws Exception {
+    public void setup() {
+        IdentityServerTestUtils.initInstanceForTest();
 
         context =
                 new TransactionIdContext(
@@ -200,40 +203,49 @@ public class RouterActivityLoggerTest {
 
     @Test
     public void testRootActivityLoggerWithLogFullObjectsOn() throws Exception {
-        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-        Connection connection = mock(Connection.class);
-        when(connectionFactory.getConnection()).thenReturn(connection);
-        when(connection.create(any(Context.class), any(CreateRequest.class))).thenReturn(
-                Responses.newResourceResponse("ba", "1", null));
-        ActionResponse actionResponse = Responses.newActionResponse(json(array("test")));
-        when(connection.action(any(Context.class), any(ActionRequest.class))).thenReturn(actionResponse);
-        ArgumentCaptor<CreateRequest> createRequestArgumentCaptor = ArgumentCaptor.forClass(CreateRequest.class);
+        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
 
-        // given
-        IdentityServer.initInstance(new PropertyAccessor() {
-            @Override
-            @SuppressWarnings("unchecked")
-            public <T> T getProperty(String key, T defaultValue, Class<T> expected) {
-                if (key.equals(RouterActivityLogger.OPENIDM_AUDIT_LOG_FULL_OBJECTS)) {
-                    return (T) "true";
+        try {
+            ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+            Connection connection = mock(Connection.class);
+            when(connectionFactory.getConnection()).thenReturn(connection);
+            when(connection.create(any(Context.class), any(CreateRequest.class))).thenReturn(
+                    Responses.newResourceResponse("ba", "1", null));
+            ActionResponse actionResponse = Responses.newActionResponse(json(array("test")));
+            when(connection.action(any(Context.class), any(ActionRequest.class))).thenReturn(actionResponse);
+            ArgumentCaptor<CreateRequest> createRequestArgumentCaptor = ArgumentCaptor.forClass(CreateRequest.class);
+
+            IdentityServerTestUtils.clearServerInitialization();
+
+            // given
+            IdentityServer.initInstance(new PropertyAccessor() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T> T getProperty(String key, T defaultValue, Class<T> expected) {
+                    if (key.equals(RouterActivityLogger.OPENIDM_AUDIT_LOG_FULL_OBJECTS)) {
+                        return (T) "true";
+                    }
+                    return defaultValue;
                 }
-                return defaultValue;
-            }
-        });
+            });
 
-        // when
-        RouterActivityLogger activityLogger = new RouterActivityLogger(connectionFactory);
-        activityLogger.log(context, request, TEST_MESSAGE, TEST_OBJECT_ID, before, after, Status.SUCCESS);
+            // when
+            RouterActivityLogger activityLogger = new RouterActivityLogger(connectionFactory);
+            activityLogger.log(context, request, TEST_MESSAGE, TEST_OBJECT_ID, before, after, Status.SUCCESS);
 
-        // then
-        verify(connection).create(any(Context.class), createRequestArgumentCaptor.capture());
+            // then
+            verify(connection).create(any(Context.class), createRequestArgumentCaptor.capture());
 
-        JsonValue content = createRequestArgumentCaptor.getValue().getContent();
+            JsonValue content = createRequestArgumentCaptor.getValue().getContent();
 
-        JsonValue capturedAfter = content.get(OpenIDMActivityAuditEventBuilder.AFTER);
+            JsonValue capturedAfter = content.get(OpenIDMActivityAuditEventBuilder.AFTER);
 
-        String rev = capturedAfter.get(ResourceResponse.FIELD_CONTENT_REVISION).asString();
-        assertThat(rev).isEqualTo("2");
-
+            String rev = capturedAfter.get(ResourceResponse.FIELD_CONTENT_REVISION).asString();
+            assertThat(rev).isEqualTo("2");
+        }
+        finally {
+            // Reset state for subsequent tests
+            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
+        }
     }
 }

--- a/openidm-util/src/test/java/org/forgerock/openidm/audit/util/RouterActivityLoggerTest.java
+++ b/openidm-util/src/test/java/org/forgerock/openidm/audit/util/RouterActivityLoggerTest.java
@@ -242,8 +242,7 @@ public class RouterActivityLoggerTest {
 
             String rev = capturedAfter.get(ResourceResponse.FIELD_CONTENT_REVISION).asString();
             assertThat(rev).isEqualTo("2");
-        }
-        finally {
+        } finally {
             // Reset state for subsequent tests
             IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
         }

--- a/openidm-util/src/test/java/org/forgerock/openidm/audit/util/RouterActivityLoggerTest.java
+++ b/openidm-util/src/test/java/org/forgerock/openidm/audit/util/RouterActivityLoggerTest.java
@@ -41,7 +41,7 @@ import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.Responses;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.PropertyAccessor;
-import org.forgerock.openidm.core.util.IdentityServerTestUtils;
+import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.services.TransactionId;
 import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
@@ -89,7 +89,6 @@ public class RouterActivityLoggerTest {
         ));
 
     }
-
 
     @Test
     public void testRootActivityLoggerWithBeforeAndAfter() throws Exception {
@@ -203,7 +202,7 @@ public class RouterActivityLoggerTest {
 
     @Test
     public void testRootActivityLoggerWithLogFullObjectsOn() throws Exception {
-        final IdentityServer instanceBeforeTest = IdentityServerTestUtils.getServerInstance();
+        final IdentityServer instanceBeforeTest = IdentityServer.getInstance();
 
         try {
             ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -244,7 +243,8 @@ public class RouterActivityLoggerTest {
             assertThat(rev).isEqualTo("2");
         } finally {
             // Reset state for subsequent tests
-            IdentityServerTestUtils.setServerInstance(instanceBeforeTest);
+            IdentityServerTestUtils.clearServerInitialization();
+            IdentityServer.initInstance(instanceBeforeTest);
         }
     }
 }


### PR DESCRIPTION
Several issues being fixed:
  - FR was statically initializing the `IDENTITY_SERVER` `AtomicReference` to a placeholder instance that provided different information to other IDM components _during_ initialization than the final instance did _after_ initialization.
  - FR was using an AtomicBoolean to guard updates to the the `IDENTITY_SERVER` `AtomicReference`, without explicitly using a `synchronized` critical section. So, any calls into the `IdentityService` instance between the time the server was marked "initialized" and the time the instance was set would actually be interacting with the default (placeholder) instance without realizing it.
  - Because of the behaviors above, code like `SelfService` came to rely on being able to get an `IdentityServer` instance during its static class initializer. This was bad -- depending upon whether the `SelfService` class was loaded before, during, or after `IdentityServer` was fully initialized, it would be getting informaton from either the default (placeholder) instance of `IdentityServer` or the actual instance.
  - `IdentityServer.getInstance()` was checking for initialization with a `null` check that would never fail, because the value was always initialized to a non-null value.
  - `IdentitySever.initInstance(IdentityServer)` would not throw a `IllegalStateException` if it was passed a `null` value.

Now:
  - Both the the `IDENTITY_SERVER` `AtomicReference` and the `INITIALISED` `AtomicBoolean` are gone.
  - There's just one volatile static instance variable that's initialized in a `synchronized` critical section.
  - All components of IDM that need an instance of `IdentityServer` can only interact with it once it's been initialized; this is now enforced properly by the `getInstance()` method.
  - `SelfService` uses a shared key alias that is lazily-initialized by a double-checked locking pattern, so that it doesn't need the `IdentityServer` to be initialized at class loading time.
  - There are tests that actually cover both overloads of `initInstance()`.
  - A utility class now exists for tests to manipulate the state of `IdentityServer`.
  - Fixed broken tests by making sure all tests that depend on `IdentityServer` initialize it before or during the test.
  - Fixed test failures in `openidm-security` that were dependent on file order. Here's what was happening:
    - If `EntryResourceProviderTest` was loaded by the JVM before `PrivateKeyResourceProviderTest`, then all tests would pass.
    - If `EntryResourceProviderTest` was loaded by the JVM after `PrivateKeyResourceProviderTest`, then tests for `EntryResourceProviderTest`, `KeystoreResourceProviderTest`, and `PrivateKeyResourceProviderTest` would fail.