### PR TITLE
[#60] Ignore Missing "preferences" Field in Mapping UI

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/association/IndividualRecordValidationView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/association/IndividualRecordValidationView.js
@@ -61,7 +61,9 @@ define([
 
             ConfigDelegate.readEntity("managed").then((managed) => {
                 _.each(managed.objects, function(managedObject) {
-                    if(managedObject.name === "user") {
+                    if((managedObject.name === "user")
+                        && managedObject.schema.properties.preferences
+                        && managedObject.schema.properties.preferences.properties) {
                         this.data.preferences = managedObject.schema.properties.preferences.properties;
                         this.model.allPreferences = _.keys(this.data.preferences);
                     }


### PR DESCRIPTION
Prevents `IndividualRecordValidationView.js:48 Uncaught TypeError: Cannot read property 'properties' of undefined` when the `preferences` field does not exist in a `user` managed object type.

Closes #60.