### PR TITLE
[6.0] Switch to `wrensec-parent` 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock</groupId>
-        <artifactId>forgerock-parent</artifactId>
-        <version>2.0.10</version>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>2.2.0</version>
     </parent>
 
     <groupId>org.forgerock.openidm</groupId>
@@ -73,6 +73,21 @@
 
             <releases>
                 <enabled>true</enabled>
+            </releases>
+        </repository>
+        
+        <!-- Needed to retrieve parent POM -->
+        <repository>
+            <id>wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>false</enabled>
             </releases>
         </repository>
     </repositories>


### PR DESCRIPTION
The new version upgrades PGP Verify to 1.3.0-wren3, which:
  - Makes it possible to build with PGP verification on, without having to sign the entire build (enhances both CI and local builds); now reactor deps are ignored during verification.
  - Makes the client recover from intermittent PGP key server failures.