### PR TITLE
Remove invalid integer type for managed object properties (#41)

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/schema/SchemaEditorView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/schema/SchemaEditorView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2018 Wren Security
  */
 
 define([
@@ -241,10 +242,6 @@ define([
                                     "title": "Boolean",
                                     "type": "string",
                                     "displayType" : "Boolean",
-                                    "format": "hidden"
-                                }, {
-                                    "title": "Integer",
-                                    "type": "string",
                                     "format": "hidden"
                                 }, {
                                     "title": "Number",
@@ -685,7 +682,6 @@ define([
             // Copy over advanced properties
             switch (property.type) {
                 case "boolean":
-                case "integer":
                 case "number":
                     if (forArray) {
                         tempProperty.itemType = {

--- a/openidm-ui/openidm-ui-admin/src/test/qunit/org/forgerock/openidm/ui/admin/managed/schema/util/SchemaUtilsTest.js
+++ b/openidm-ui/openidm-ui-admin/src/test/qunit/org/forgerock/openidm/ui/admin/managed/schema/util/SchemaUtilsTest.js
@@ -14,7 +14,7 @@ define([
                 ]
             },
             "prop3": {
-                "type": "integer"
+                "type": "boolean"
             },
             "prop4": {
                 "type": [
@@ -32,7 +32,7 @@ define([
                 "nullable": true
             },
             "prop3": {
-                "type": "integer"
+                "type": "boolean"
             },
             "prop4": {
                 "type": "object",


### PR DESCRIPTION
Removed invalid *integer* type for managed object property definition. There is a **number** type that should be used instead of invalid *integer* type.

See [OPENIDM-7226](https://bugster.forgerock.org/jira/browse/OPENIDM-7226).
