### PR TITLE
Update PostgreSQL JDBC driver (#66)

### DIFF
--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -587,11 +587,11 @@
             <version>1.2</version>
         </dependency>
 
-        <!-- jdbc drivers -->
+        <!-- JDBC drivers -->
         <dependency>
             <groupId>org.postgresql</groupId>
-            <artifactId>postgresql-fr-osgi</artifactId>
-            <version>9.3-1101-jdbc41</version>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.18</version>
         </dependency>
 
         <!-- Javascript libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 
     <properties>
 
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.4.4</pgpWhitelistArtifact>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.4.5</pgpWhitelistArtifact>
 
         <!-- Version management -->
         <commons.commons-bom.version>22.0.0</commons.commons-bom.version>


### PR DESCRIPTION
PostgreSQL JDBC driver has been upgraded to latest version **42.2.14.jre7**.  Signature has been updated in https://github.com/WrenSecurity/wrensec-pgp-whitelist/pull/9