### PR TITLE
Upgrade Felix, OSGi and JRE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ node_modules
 
 # ctags index
 tags
+
+# TestNG
+*/test-output

--- a/custom-scripted-connector-bundler/pom.xml
+++ b/custom-scripted-connector-bundler/pom.xml
@@ -3,7 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2015 ForgeRock AS. All rights reserved.
- Portions Copyright 2017-2018 Wren Security.
+ Portions Copyright 2017-2020 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -34,7 +34,6 @@
 
     <groupId>org.forgerock.openidm.tools</groupId>
     <artifactId>custom-scripted-connector-bundler</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
 
     <name>Wren:IDM - Custom Groovy Connector Bundler</name>
     <description>
@@ -102,7 +101,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
         </dependency>
     </dependencies>
 

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/ScriptedBundler.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/ScriptedBundler.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -24,18 +25,19 @@
 
 package org.forgerock.openidm.tools.scriptedbundler;
 
-import org.apache.commons.cli.BasicParser;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.ParseException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * This is the main class for this project.  It accepts a JSON configuration file and attempts to generate a set of
@@ -69,7 +71,7 @@ public class ScriptedBundler {
                 .append(ScriptedBundler.class.getPackage().getImplementationVersion());
         System.out.println(str);
 
-        CommandLineParser parser = new BasicParser();
+        CommandLineParser parser = new DefaultParser();
         CommandLine cmdline = null;
         try {
             cmdline = parser.parse(options, args);

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/SourceGenerator.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/SourceGenerator.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -35,6 +36,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -125,7 +127,7 @@ public class SourceGenerator {
                 hbtemplate = hb.compileInline(out.toString());
                 String contents = hbtemplate.apply(config);
 
-                FileUtils.write(new File(outputPath + outputFilename), contents);
+                FileUtils.write(new File(outputPath + outputFilename), contents, StandardCharsets.UTF_8);
             } catch (Exception e) {
                 throw new IOException("Failed to read contents of " + template.getInputName(), e);
             }
@@ -162,7 +164,7 @@ public class SourceGenerator {
             }
             contents += out.toString();
 
-            FileUtils.write(new File(outputPath + outputFilename), contents);
+            FileUtils.write(new File(outputPath + outputFilename), contents, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new IOException("Failed to read contents of " + uiTemplate.getInputName(), e);
         }

--- a/openidm-api-servlet/pom.xml
+++ b/openidm-api-servlet/pom.xml
@@ -13,7 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2013-2016 ForgeRock AS.
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -108,12 +108,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -175,21 +169,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ErrorServletComponent.java
+++ b/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ErrorServletComponent.java
@@ -12,29 +12,30 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.servlet.internal;
+
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.io.IOException;
-import java.util.Dictionary;
-import java.util.Hashtable;
-
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Reference;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.forgerock.openidm.jetty.JettyErrorHandler;
 import org.forgerock.openidm.servletregistration.ServletRegistration;
 import org.ops4j.pax.web.service.WebContainer;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,10 @@ import org.slf4j.LoggerFactory;
 /**
  * A component to create and register a Jetty error-handler servlet.
  */
-@Component(name = ErrorServletComponent.PID, policy = ConfigurationPolicy.IGNORE, immediate = true)
+@Component(
+        name = ErrorServletComponent.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true)
 public class ErrorServletComponent {
 
     static final String PID = "org.forgerock.openidm.error-servlet";

--- a/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletComponent.java
+++ b/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletComponent.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.servlet.internal;
 
@@ -19,28 +20,16 @@ import static org.forgerock.openidm.servletregistration.ServletRegistration.SERV
 import static org.forgerock.openidm.servletregistration.ServletRegistration.SERVLET_FILTER_SCRIPT_EXTENSIONS;
 
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import javax.script.ScriptException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 
-import io.swagger.models.Info;
-import io.swagger.models.Swagger;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.ReferenceStrategy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.http.ApiProducer;
 import org.forgerock.http.DescribedHttpApplication;
 import org.forgerock.http.Filter;
@@ -63,12 +52,24 @@ import org.forgerock.script.ScriptRegistry;
 import org.forgerock.util.Factory;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.osgi.service.event.Event;
-import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.swagger.models.Info;
+import io.swagger.models.Swagger;
 
 /**
  * A component to create and register the "API" Servlet; that is, the CHF Servlet that
@@ -80,13 +81,14 @@ import org.slf4j.LoggerFactory;
  *       i) converts CHF Requests to CREST requests, and
  *       ii) routes them on the CREST router using the external ConnectionFactory.
  */
-@Component(name = ServletComponent.PID, policy = ConfigurationPolicy.IGNORE, immediate = true)
-@Service
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Common REST HttpServlet"),
-    @Property(name = EventConstants.EVENT_TOPIC, value = { "org/forgerock/openidm/servlet/*" })
-})
+@Component(
+        name = ServletComponent.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        property = Constants.SERVICE_PID + "=" + ServletComponent.PID)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Common REST HttpServlet")
+@EventTopics("org/forgerock/openidm/servlet/*")
 public class ServletComponent implements EventHandler {
 
     static final String PID = "org.forgerock.openidm.api-servlet";
@@ -118,17 +120,15 @@ public class ServletComponent implements EventHandler {
     private List<ScriptEntry> augmentSecurityScripts = new CopyOnWriteArrayList<>();
 
     // Register script extensions configured
+    private Map<ServletFilterRegistrator, ScriptEntry> filterRegistratorMap = new ConcurrentHashMap<>();
+
     @Reference(
             name = "reference_Servlet_ServletFilterRegistrator",
-            referenceInterface = ServletFilterRegistrator.class,
-            bind = "bindRegistrator",
+            service = ServletFilterRegistrator.class,
             unbind = "unbindRegistrator",
-            cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE,
-            policy = ReferencePolicy.DYNAMIC,
-            strategy = ReferenceStrategy.EVENT
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC
     )
-    private Map<ServletFilterRegistrator, ScriptEntry> filterRegistratorMap = new HashMap<>();
-
     protected synchronized void bindRegistrator(ServletFilterRegistrator registrator, Map<String, Object> properties) {
         JsonValue scriptConfig = registrator.getConfiguration()
                 .get(SERVLET_FILTER_SCRIPT_EXTENSIONS)

--- a/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletConnectionFactory.java
+++ b/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletConnectionFactory.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Copyright 2017-2018 Wren Security.
+ * Copyright 2017-2020 Wren Security.
  */
 
 package org.forgerock.openidm.servlet.internal;
@@ -98,11 +98,11 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
     private static final Filter SERVICE_UNAVAILABLE_FILTER = new ServiceUnavailableFilter("Service is starting");
 
     /** the Request Handler (Router) */
-    @Reference(target = "(org.forgerock.openidm.router=*)")
+    @Reference(target = "(org.forgerock.openidm.router=*)", bind = "bindRequestHandler")
     private RequestHandler requestHandler = null;
 
     /** Enhanced configuration service. */
-    @Reference(policy = ReferencePolicy.DYNAMIC)
+    @Reference(policy = ReferencePolicy.DYNAMIC, bind = "bindEnhancedConfig")
     private volatile EnhancedConfig enhancedConfig = null;
 
     /**
@@ -142,6 +142,14 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
 
     /** the created connection factory */
     protected ConnectionFactory connectionFactory;
+
+    void bindRequestHandler(RequestHandler requestHandler) {
+        this.requestHandler = requestHandler;
+    }
+
+    void bindEnhancedConfig(EnhancedConfig enhancedConfig) {
+        this.enhancedConfig = enhancedConfig;
+    }
 
     /**
      * Assign the maintenance filter delegate to the provided filter.

--- a/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletConnectionFactory.java
+++ b/openidm-api-servlet/src/main/java/org/forgerock/openidm/servlet/internal/ServletConnectionFactory.java
@@ -24,16 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.resource.AbstractConnectionWrapper;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
@@ -60,8 +50,8 @@ import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.external.ExternalException;
-import org.forgerock.openidm.filter.PassthroughFilter;
 import org.forgerock.openidm.filter.MutableFilterDecorator;
+import org.forgerock.openidm.filter.PassthroughFilter;
 import org.forgerock.openidm.filter.ServiceUnavailableFilter;
 import org.forgerock.openidm.router.RouterFilterRegistration;
 import org.forgerock.openidm.smartevent.EventEntry;
@@ -73,6 +63,15 @@ import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.ResultHandler;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,12 +79,13 @@ import org.slf4j.LoggerFactory;
  * The ServletConnectionFactory responsible for providing Connections to routing requests initiated
  * from an external request on the api servlet.
  */
-@Component(name = ServerConstants.EXTERNAL_ROUTER_SERVICE_PID, policy = ConfigurationPolicy.IGNORE, immediate = true)
-@Service({ ConnectionFactory.class, RouterFilterRegistration.class })
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Common REST Servlet Connection Factory")
-})
+@Component(
+        name = ServerConstants.EXTERNAL_ROUTER_SERVICE_PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        property = Constants.SERVICE_PID + "=" + ServerConstants.EXTERNAL_ROUTER_SERVICE_PID)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Common REST Servlet Connection Factory")
 public class ServletConnectionFactory implements ConnectionFactory, RouterFilterRegistration {
 
     /** Event name prefix for monitoring the router */
@@ -102,7 +102,7 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
     private RequestHandler requestHandler = null;
 
     /** Enhanced configuration service. */
-    @Reference(policy = ReferencePolicy.DYNAMIC, bind = "bindEnhancedConfig")
+    @Reference(policy = ReferencePolicy.DYNAMIC)
     private volatile EnhancedConfig enhancedConfig = null;
 
     /**
@@ -121,20 +121,12 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
     private final MutableFilterDecorator startupFilter = new MutableFilterDecorator(SERVICE_UNAVAILABLE_FILTER);
 
     /** A wrapper for the maintenance filter - populated when the MaintenanceFilter is bound */
-    @Reference(name = "MaintenanceFilter", referenceInterface = Filter.class,
-            target = "(service.pid=org.forgerock.openidm.maintenance.filter)",
-            bind = "bindMaintenanceFilter", unbind = "unbindMaintenanceFilter",
-            cardinality = ReferenceCardinality.OPTIONAL_UNARY, policy = ReferencePolicy.DYNAMIC)
     private final MutableFilterDecorator maintenanceFilter = new MutableFilterDecorator();
 
     /** A filter to emit trace messages on the request and response */
     private final Filter loggingFilter = newTraceLoggingFilter();
 
     /** A wrapper for the audit filter - populated when the AuditFilter is bound */
-    @Reference(name = "AuditFilter", referenceInterface = Filter.class,
-            target = "(service.pid=org.forgerock.openidm.audit.filter)",
-            bind = "bindAuditFilter", unbind = "unbindAuditFilter",
-            cardinality = ReferenceCardinality.OPTIONAL_UNARY, policy = ReferencePolicy.DYNAMIC)
     private final MutableFilterDecorator auditFilter = new MutableFilterDecorator();
 
     /** the constructed filter chain */
@@ -156,6 +148,13 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
      *
      * @param filter the active maintenance filter
      */
+    @Reference(
+            name = "MaintenanceFilter",
+            service = Filter.class,
+            target = "(component.name=org.forgerock.openidm.maintenance.filter)",
+            unbind = "unbindMaintenanceFilter",
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC)
     void bindMaintenanceFilter(Filter filter) {
         maintenanceFilter.setDelegate(filter);
     }
@@ -174,6 +173,13 @@ public class ServletConnectionFactory implements ConnectionFactory, RouterFilter
      *
      * @param filter the active audit filter
      */
+    @Reference(
+            name = "AuditFilter",
+            service = Filter.class,
+            target = "(component.name=org.forgerock.openidm.audit.filter)",
+            unbind = "unbindAuditFilter",
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC)
     void bindAuditFilter(Filter filter) {
         auditFilter.setDelegate(filter);
     }

--- a/openidm-audit/pom.xml
+++ b/openidm-audit/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright 2011-2015 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -105,13 +105,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.forgerock.commons</groupId>
@@ -152,21 +145,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-audit/src/main/java/org/forgerock/openidm/audit/filter/AuditFilter.java
+++ b/openidm-audit/src/main/java/org/forgerock/openidm/audit/filter/AuditFilter.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.audit.filter;
@@ -23,20 +24,9 @@ import static org.forgerock.json.resource.Requests.newCreateRequest;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 import static org.forgerock.util.promise.Promises.newResultPromise;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.audit.events.AccessAuditEventBuilder;
-import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.AbstractAsynchronousConnection;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
@@ -66,9 +56,14 @@ import org.forgerock.util.promise.ExceptionHandler;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.ResultHandler;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,13 +71,14 @@ import org.slf4j.LoggerFactory;
 /**
  * A router {@link Filter} to log external CREST requests as access events.
  */
-@Component(name = AuditFilter.PID, policy = ConfigurationPolicy.IGNORE, immediate = true)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "Audit Router Filter")
-})
+@Component(
+        name = AuditFilter.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Audit Router Filter")
 public class AuditFilter implements Filter {
+
     static final String PID = "org.forgerock.openidm.audit.filter";
 
     private static final Logger logger = LoggerFactory.getLogger(AuditFilter.class);

--- a/openidm-audit/src/main/java/org/forgerock/openidm/audit/impl/AuditLogFilters.java
+++ b/openidm-audit/src/main/java/org/forgerock/openidm/audit/impl/AuditLogFilters.java
@@ -12,16 +12,17 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.audit.impl;
 
 import static org.forgerock.json.JsonValueFunctions.enumConstant;
-import static org.forgerock.json.JsonValueFunctions.setOf;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.script.ScriptException;
@@ -83,7 +84,7 @@ public class AuditLogFilters {
                 public AuditLogFilter apply(JsonValue value) {
                     return newFieldValueFilter(
                             new JsonPointer(value.get("name").required().asString()),
-                            value.get("values").required().as(setOf(String.class)),
+                            new LinkedHashSet<>(value.get("values").required().asList(String.class)),
                             AS_STRING); // currently assumes values are strings
                 }
             };
@@ -121,6 +122,7 @@ public class AuditLogFilters {
 
         private ActionFilter(final Class<A> clazz, final Set<A> actionsToLog) {
             super(FIELD_ACTION, actionsToLog, new JsonValueObjectConverter<A>() {
+                @Override
                 public A apply(JsonValue value) throws JsonValueException {
                     return value.as(enumConstant(clazz));
                 }
@@ -154,6 +156,7 @@ public class AuditLogFilters {
 
         private OperationFilter(final Class<A> clazz, final Set<A> actionsToLog) {
             super(OPERATION, actionsToLog, new JsonValueObjectConverter<A>() {
+                @Override
                 public A apply(JsonValue value) throws JsonValueException {
                     return value.as(enumConstant(clazz));
                 }

--- a/openidm-audit/src/main/java/org/forgerock/openidm/audit/impl/AuditServiceImpl.java
+++ b/openidm-audit/src/main/java/org/forgerock/openidm/audit/impl/AuditServiceImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.audit.impl;
 
@@ -119,22 +120,22 @@ public class AuditServiceImpl implements AuditService {
      if using this with for scr 1.6.2
      Ensure we do not get bound on router whilst it is activating
      */
-    @Reference(target = "("+ServerConstants.ROUTER_PREFIX + "=/*)")
+    @Reference(target = "("+ServerConstants.ROUTER_PREFIX + "=/*)", bind = "bindRouteService")
     private RouteService routeService;
 
     /** Script Registry service. */
-    @Reference(policy = ReferencePolicy.STATIC)
+    @Reference(policy = ReferencePolicy.STATIC, bind = "bindScriptRegistry")
     private ScriptRegistry scriptRegistry;
 
     private AuditServiceProxy auditService;
     private JsonValue config; // Existing active configuration
 
     /** Enhanced configuration service. */
-    @Reference(policy = ReferencePolicy.DYNAMIC)
+    @Reference(policy = ReferencePolicy.DYNAMIC, bind = "bindEnhancedConfig")
     private volatile EnhancedConfig enhancedConfig;
 
     /** Enhanced configuration service. */
-    @Reference
+    @Reference(bind = "bindCryptoService")
     private CryptoService cryptoService;
 
     /** the script to execute to format exceptions */
@@ -241,6 +242,22 @@ public class AuditServiceImpl implements AuditService {
      * call their useForQueriesMethod.
      */
     private final Map<String, EventHandlerConfiguration> dummyAuditEventHandlers = new LinkedHashMap<>();
+
+    void bindRouteService(RouteService routeService) {
+        this.routeService = routeService;
+    }
+
+    void bindScriptRegistry(ScriptRegistry scriptRegistry) {
+        this.scriptRegistry = scriptRegistry;
+    }
+
+    void bindEnhancedConfig(EnhancedConfig enhancedConfig) {
+        this.enhancedConfig = enhancedConfig;
+    }
+
+    void bindCryptoService(CryptoService cryptoService) {
+        this.cryptoService = cryptoService;
+    }
 
     @Activate
     void activate(ComponentContext compContext) throws Exception {

--- a/openidm-audit/src/test/java/org/forgerock/openidm/audit/events/handlers/impl/PassThroughAuditEventHandler.java
+++ b/openidm-audit/src/test/java/org/forgerock/openidm/audit/events/handlers/impl/PassThroughAuditEventHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.audit.events.handlers.impl;
@@ -29,24 +30,16 @@ import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles AuditEvents by just calling the result Handler.
  */
 public class PassThroughAuditEventHandler extends AuditEventHandlerBase {
 
-    private static final Logger logger = LoggerFactory.getLogger(PassThroughAuditEventHandlerConfiguration.class);
-
-    /** A message logged when a new entry is added. */
-    private final String message;
-
     public PassThroughAuditEventHandler(
             final PassThroughAuditEventHandlerConfiguration configuration,
             final EventTopicsMetaData eventTopicsMetaData) {
         super(configuration.getName(), eventTopicsMetaData , configuration.getTopics(), configuration.isEnabled());
-        this.message = configuration.getMessage();
     }
 
     @Override

--- a/openidm-authnfilter/pom.xml
+++ b/openidm-authnfilter/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2015 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -147,12 +147,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -180,21 +174,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/AuthFilterWrapper.java
+++ b/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/AuthFilterWrapper.java
@@ -12,14 +12,10 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.auth;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.http.Filter;
 import org.forgerock.http.Handler;
 import org.forgerock.http.protocol.Request;
@@ -27,17 +23,26 @@ import org.forgerock.http.protocol.Response;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
 
 /**
  * A CHF {@link Filter} to wrap the {@link org.forgerock.caf.authentication.framework.AuthenticationFilter},
  * so that config changes may swap out the CAF AuthenticationFilter without disturbing the CHF
  * {@link org.forgerock.json.resource.FilterChain}.
  */
-@Component(name = AuthFilterWrapper.PID, policy = ConfigurationPolicy.IGNORE,
-        configurationFactory = false, immediate = true)
-@Service(value = { Filter.class, AuthFilterWrapper.class })
+@Component(
+        name = AuthFilterWrapper.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        property = Constants.SERVICE_PID + "=" + AuthFilterWrapper.PID,
+        service = { Filter.class, AuthFilterWrapper.class })
 public class AuthFilterWrapper implements Filter {
+
     public static final String PID = "org.forgerock.openidm.auth.config";
 
     /** Null Object Filter to forward request on when authentication filter is not configured. */

--- a/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/modules/IDMAuthModuleWrapper.java
+++ b/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/modules/IDMAuthModuleWrapper.java
@@ -14,7 +14,7 @@
  * "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security
  */
 package org.forgerock.openidm.auth.modules;
 
@@ -299,7 +299,6 @@ public class IDMAuthModuleWrapper implements AsyncServerAuthModule {
      * @param serviceSubject {@inheritDoc}
      * @return {@inheritDoc}
      */
-    @SuppressWarnings("unchecked")
     @Override
     public Promise<AuthStatus, AuthenticationException> validateRequest(final MessageInfoContext messageInfo,
             final Subject clientSubject, Subject serviceSubject) {
@@ -441,7 +440,6 @@ public class IDMAuthModuleWrapper implements AsyncServerAuthModule {
      * @param serviceSubject {@inheritDoc}
      * @return {@inheritDoc}
      */
-    @SuppressWarnings("unchecked")
     @Override
     public Promise<AuthStatus, AuthenticationException> secureResponse(MessageInfoContext messageInfo,
             Subject serviceSubject) {

--- a/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/modules/oauth/OAuthModule.java
+++ b/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/modules/oauth/OAuthModule.java
@@ -12,17 +12,17 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.auth.modules.oauth;
 
+import static javax.security.auth.message.AuthStatus.SEND_FAILURE;
+import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
 import static org.forgerock.caf.authentication.framework.AuthenticationFramework.LOG;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.util.promise.Promises.newExceptionPromise;
 import static org.forgerock.util.promise.Promises.newResultPromise;
-import static javax.security.auth.message.AuthStatus.SEND_FAILURE;
-import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -33,7 +33,6 @@ import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.message.AuthException;
 import javax.security.auth.message.AuthStatus;
 import javax.security.auth.message.MessagePolicy;
 import javax.security.auth.message.callback.CallerPrincipalCallback;

--- a/openidm-authnfilter/src/test/java/org/forgerock/openidm/auth/modules/DelegatedAuthModuleTest.java
+++ b/openidm-authnfilter/src/test/java/org/forgerock/openidm/auth/modules/DelegatedAuthModuleTest.java
@@ -12,21 +12,29 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.auth.modules;
 
-import static org.forgerock.json.JsonValue.*;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.security.auth.Subject;
 import javax.security.auth.message.AuthException;
 import javax.security.auth.message.AuthStatus;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.forgerock.caf.authentication.api.AuthenticationException;
 import org.forgerock.caf.authentication.api.MessageInfoContext;
@@ -37,8 +45,6 @@ import org.forgerock.json.resource.ResourceException;
 import org.forgerock.openidm.auth.Authenticator;
 import org.forgerock.openidm.auth.Authenticator.AuthenticatorResult;
 import org.forgerock.openidm.auth.AuthenticatorFactory;
-import org.forgerock.services.context.Context;
-import org.mockito.Matchers;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -178,7 +184,7 @@ public class DelegatedAuthModuleTest {
 
         given(authResult.isAuthenticated()).willReturn(true);
         given(authenticator.authenticate(eq("USERNAME"), eq("PASSWORD"),
-                Matchers.<Context>anyObject())).willReturn(authResult);
+                any())).willReturn(authResult);
 
         //When
         AuthStatus authStatus = module.validateRequest(messageInfo, clientSubject, serviceSubject)
@@ -210,7 +216,7 @@ public class DelegatedAuthModuleTest {
 
         given(authResult.isAuthenticated()).willReturn(false);
         given(authenticator.authenticate(eq("USERNAME"), eq("PASSWORD"),
-                Matchers.<Context>anyObject())).willReturn(authResult);
+                any())).willReturn(authResult);
 
         //When
         AuthStatus authStatus = module.validateRequest(messageInfo, clientSubject, serviceSubject)

--- a/openidm-authnfilter/src/test/java/org/forgerock/openidm/auth/modules/IDMAuthModuleWrapperTest.java
+++ b/openidm-authnfilter/src/test/java/org/forgerock/openidm/auth/modules/IDMAuthModuleWrapperTest.java
@@ -12,14 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.auth.modules;
 
 import static org.forgerock.caf.authentication.framework.AuthenticationFramework.ATTRIBUTE_AUTH_CONTEXT;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMapOf;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -76,7 +76,7 @@ public class IDMAuthModuleWrapperTest {
 
             authModule = mock(AsyncServerAuthModule.class);
             authModule.initialize(any(MessagePolicy.class), any(MessagePolicy.class), any(CallbackHandler.class),
-                    anyMapOf(String.class, Object.class));
+                    anyMap());
             roleCalculatorFactory = mock(RoleCalculatorFactory.class);
             when(roleCalculatorFactory.create(ArgumentMatchers.<String>anyList(), ArgumentMatchers.<String>any(), ArgumentMatchers.<String>any(),
                     ArgumentMatchers.<String, List<String>>anyMap(),
@@ -298,7 +298,7 @@ public class IDMAuthModuleWrapperTest {
         Request request = new Request();
         given(messageInfo.getRequest()).willReturn(request);
 
-        given(authModule.secureResponse(ArgumentMatchers.<MessageInfoContext>anyObject(), ArgumentMatchers.<Subject>anyObject()))
+        given(authModule.secureResponse(any(MessageInfoContext.class), any(Subject.class)))
                 .willReturn(Promises.<AuthStatus, AuthenticationException>newResultPromise(AuthStatus.SEND_SUCCESS));
 
         //When
@@ -325,7 +325,7 @@ public class IDMAuthModuleWrapperTest {
 
         Request request = new Request();
 
-        given(authModule.secureResponse(ArgumentMatchers.<MessageInfoContext>anyObject(), ArgumentMatchers.<Subject>anyObject()))
+        given(authModule.secureResponse(any(MessageInfoContext.class), any(Subject.class)))
                 .willReturn(Promises.<AuthStatus, AuthenticationException>newResultPromise(AuthStatus.SUCCESS));
         given(messageInfo.getRequest()).willReturn(request);
         request.getHeaders().put("X-OpenIDM-NoSession", "true");
@@ -357,7 +357,7 @@ public class IDMAuthModuleWrapperTest {
 
         Request request = new Request();
 
-        given(authModule.secureResponse(ArgumentMatchers.<MessageInfoContext>anyObject(), ArgumentMatchers.<Subject>anyObject()))
+        given(authModule.secureResponse(any(MessageInfoContext.class), any(Subject.class)))
                 .willReturn(Promises.<AuthStatus, AuthenticationException>newResultPromise(AuthStatus.SUCCESS));
         given(messageInfo.getRequest()).willReturn(request);
         request.getHeaders().put("X-OpenIDM-NoSession", null);

--- a/openidm-cluster/pom.xml
+++ b/openidm-cluster/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2012-2014 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -113,32 +113,10 @@
             <artifactId>osgi.cmpn</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-config/pom.xml
+++ b/openidm-config/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -130,12 +130,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -183,20 +177,6 @@
         </resources>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-config/src/main/java/org/forgerock/openidm/config/manage/ConfigObjectService.java
+++ b/openidm-config/src/main/java/org/forgerock/openidm/config/manage/ConfigObjectService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.config.manage;
@@ -168,6 +168,10 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
     /** Scripted Patch Value Transformer Factory. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     private volatile ScriptedPatchValueTransformerFactory scriptedPatchValueTransformerFactory;
+
+    protected void bindScriptedPatchValueTransformerFactory(ScriptedPatchValueTransformerFactory scriptedPatchValueTransformerFactory) {
+        this.scriptedPatchValueTransformerFactory = scriptedPatchValueTransformerFactory;
+    }
 
     /** Enhanced configuration service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
@@ -1057,7 +1061,7 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
         }
 
         /**
-         * Prepends the fields in the configuration object with the key where the object is stored.  
+         * Prepends the fields in the configuration object with the key where the object is stored.
          * Will not modify fields outside of the configuration object.
          *
          * @param field a {@link JsonPointer} representing the field to modify.
@@ -1153,6 +1157,7 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
                     : ConfigBootstrapHelper.qualifyPid(pid);
         }
 
+        @Override
         public String toString() {
             return isFactoryConfig()
                     ? (factoryPid + "/" + instanceAlias)

--- a/openidm-config/src/main/java/org/forgerock/openidm/config/manage/ConfigObjectService.java
+++ b/openidm-config/src/main/java/org/forgerock/openidm/config/manage/ConfigObjectService.java
@@ -34,15 +34,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.api.models.ApiDescription;
 import org.forgerock.http.ApiProducer;
 import org.forgerock.json.JsonPointer;
@@ -98,25 +89,33 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Provides access to OSGi configuration.
- *
  */
 @Component(
-        name = "org.forgerock.openidm.config.manage",
+        name = ConfigObjectService.PID,
         immediate = true,
-        policy = ConfigurationPolicy.OPTIONAL
-)
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Configuration Service"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = ServerConstants.ROUTER_PREFIX, value = "/config*")
-})
-@Service(value = { RequestHandler.class })
+        configurationPolicy = ConfigurationPolicy.OPTIONAL,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/config*"
+        },
+        service = RequestHandler.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Configuration Service")
 public class ConfigObjectService implements RequestHandler, ClusterEventListener, Describable<ApiDescription, Request> {
+
+    static final String PID = "org.forgerock.openidm.config.manage";
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigObjectService.class);
     private final ConfigAuditEventLogger auditLogger;
@@ -488,7 +487,6 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
      *            <dd>If the passed identifier is invalid</dd>
      *          </dl>
      */
-    @SuppressWarnings("rawtypes")
     private Promise<ConfigAuditState, ResourceException> update(ResourcePath resourcePath, String rev,
             JsonValue obj) {
         logger.debug("Invoking update configuration {} {}", resourcePath.toString(), rev);
@@ -587,7 +585,6 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
      * ConflictException:           if version is required but is {@code null}.
      * PreconditionFailedException: if version did not match the existing object in the set.
      */
-    @SuppressWarnings("rawtypes")
     private Promise<ConfigAuditState, ResourceException> delete(ResourcePath resourcePath,
                                                                String rev) {
         logger.debug("Invoking delete configuration {} {}", resourcePath.toString(), rev);
@@ -649,7 +646,6 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
                         });
     }
 
-    @SuppressWarnings("rawtypes")
     private Promise<ConfigAuditState, ResourceException> patch(final Context context, final ResourcePath resourcePath,
             final List<PatchOperation> patchOperation) {
         final ParsedId parsedId;

--- a/openidm-config/src/main/java/org/forgerock/openidm/config/persistence/ConfigInstallStarter.java
+++ b/openidm-config/src/main/java/org/forgerock/openidm/config/persistence/ConfigInstallStarter.java
@@ -12,38 +12,39 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.config.persistence;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
+import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.crypto.CryptoService;
 import org.forgerock.openidm.repo.RepoBootService;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts the configuration installation handling once the 
- * basic services for it are available
- *
+ * Starts the configuration installation handling once the basic services for it
+ * are available
  */
 @Component(
-    name = "org.forgerock.openidm.config.enhanced.starter",
-    policy = ConfigurationPolicy.OPTIONAL,
-    immediate = true
-)
-@Properties({
-    @Property(name = "service.description", value = "OpenIDM internal config installation starter"),
-    @Property(name = "service.vendor", value = "ForgeRock AS")
-})
+        name = ConfigInstallStarter.PID,
+        configurationPolicy = ConfigurationPolicy.OPTIONAL,
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM internal config installation starter")
 public class ConfigInstallStarter {
+
+    static final String PID = "org.forgerock.openidm.config.enhanced.starter";
+
     final static Logger logger = LoggerFactory.getLogger(ConfigInstallStarter.class);
 
     @Reference
@@ -51,13 +52,13 @@ public class ConfigInstallStarter {
 
     @Reference
     CryptoService crypto;
-    
+
     @Reference
     protected RepoBootService repo;
-    
+
     @Reference
     ConfigPersisterMarker configPersisterMarker;
-    
+
     @Activate
     protected synchronized void activate(ComponentContext context) throws Exception {
         logger.info("Services ready to handle config install.");

--- a/openidm-config/src/test/java/org/forgerock/openidm/config/manage/ConfigObjectServiceTest.java
+++ b/openidm-config/src/test/java/org/forgerock/openidm/config/manage/ConfigObjectServiceTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.config.manage;
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
@@ -94,6 +95,7 @@ import org.forgerock.util.query.QueryFilter;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentConstants;
@@ -107,7 +109,6 @@ import org.testng.annotations.Test;
  */
 public class ConfigObjectServiceTest {
 
-    @SuppressWarnings("rawtypes")
     private Dictionary<String, Object> properties = null;
     private ConfigObjectService configObjectService;
 
@@ -117,7 +118,6 @@ public class ConfigObjectServiceTest {
     private EnhancedConfig enhancedConfig;
     private ClusterManagementService clusterManagementService;
 
-    @SuppressWarnings("unchecked")
     @BeforeTest
     public void beforeTest() throws Exception {
         IdentityServerTestUtils.initInstanceForTest();
@@ -259,7 +259,6 @@ public class ConfigObjectServiceTest {
 
     }
 
-    @SuppressWarnings("rawtypes")
     @Test(priority=3)
     public void testCreateNew() throws Exception {
         config.put("property1", "value1");
@@ -285,7 +284,6 @@ public class ConfigObjectServiceTest {
         throw new Exception("Duplicate object not detected");
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test(priority=5)
     public void testCreateDupeOk() throws Exception {
         configObjectService.create(rname, id, json(config), true).getOrThrow();
@@ -323,7 +321,6 @@ public class ConfigObjectServiceTest {
                 newQueryRequest(""), mock(QueryResourceHandler.class)).getOrThrow();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(priority=8)
     public void testDelete() throws Exception {
         configObjectService.handleDelete(new TransactionIdContext(new RootContext(), new TransactionId()),
@@ -427,9 +424,19 @@ public class ConfigObjectServiceTest {
             }
             return null;
         }
+
+        @Override
+        public Configuration getFactoryConfiguration(String factoryPid, String name) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Configuration getFactoryConfiguration(String factoryPid, String name, String location)
+                throws IOException {
+            return null;
+        }
     }
 
-    @SuppressWarnings("rawtypes")
     private class MockConfiguration implements Configuration {
         String pid = "pid";
         Dictionary<String, Object> dictionary = null;
@@ -481,6 +488,29 @@ public class ConfigObjectServiceTest {
         @Override
         public long getChangeCount() {
             return 0;
+        }
+
+        @Override
+        public Dictionary<String, Object> getProcessedProperties(ServiceReference<?> reference) {
+            return null;
+        }
+
+        @Override
+        public boolean updateIfDifferent(Dictionary<String, ?> properties) throws IOException {
+            return false;
+        }
+
+        @Override
+        public void addAttributes(ConfigurationAttribute... attrs) throws IOException {
+        }
+
+        @Override
+        public Set<ConfigurationAttribute> getAttributes() {
+            return null;
+        }
+
+        @Override
+        public void removeAttributes(ConfigurationAttribute... attrs) throws IOException {
         }
     }
 

--- a/openidm-core/pom.xml
+++ b/openidm-core/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -112,13 +112,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.forgerock.commons</groupId>
@@ -199,21 +192,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>

--- a/openidm-core/src/main/java/org/forgerock/openidm/managed/DuplicateRelationshipException.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/managed/DuplicateRelationshipException.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.managed;
@@ -26,6 +27,7 @@ import org.forgerock.json.resource.PreconditionFailedException;
  * a _rev mismatch.
  */
 public class DuplicateRelationshipException extends PreconditionFailedException {
+    private static final long serialVersionUID = 1L;
     public DuplicateRelationshipException(String message) {
         super(message);
     }

--- a/openidm-core/src/main/java/org/forgerock/openidm/managed/RelationshipEqualityHash.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/managed/RelationshipEqualityHash.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.managed;
@@ -57,7 +58,7 @@ final class RelationshipEqualityHash {
         The hashCode must be composed of the relationship _ref and all non _id and _rev fields of the _refProperties.
         Note that these values must compose the hash in the same order, so the fields are hashed in the same order.
          */
-        List<Object> hashConstituents = new ArrayList();
+        List<Object> hashConstituents = new ArrayList<>();
         hashConstituents.add(relationship.get(REFERENCE_ID).getObject());
         //A TreeSet is a SortedSet, so members will be retrieved in sorted order
         Set<String> refPropertyConstituentSet = new TreeSet<>(relationshipRefProperties.keys());

--- a/openidm-core/src/main/java/org/forgerock/openidm/managed/RelationshipValidator.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/managed/RelationshipValidator.java
@@ -12,14 +12,16 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.managed;
 
 import static java.text.MessageFormat.format;
 import static org.forgerock.openidm.util.RelationshipUtil.REFERENCE_ID;
 
-import org.forgerock.openidm.util.ResourceUtil;
-import org.forgerock.util.annotations.VisibleForTesting;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.NotFoundException;
@@ -28,11 +30,9 @@ import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourcePath;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.services.context.Context;
+import org.forgerock.util.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Base class for Validators of relationship requests.  When a relationship action is determined to be invalid, the

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconTypeByQuery.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconTypeByQuery.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 
 import org.forgerock.json.JsonValue;
-import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.openidm.sync.SynchronizationException;
 
 /**
@@ -37,7 +36,7 @@ public class ReconTypeByQuery extends ReconTypeBase {
      *  Defaulting to run target phase
      */
     static final boolean DEFAULT_RUN_TARGET_PHASE = true;
-    
+
     /**
      * A {@link JsonValue} representing a source query.
      */
@@ -50,7 +49,7 @@ public class ReconTypeByQuery extends ReconTypeBase {
 
     /**
      * A constructor.
-     * 
+     *
      * @param reconContext a {@link ReconciliationContext} object.
      */
     public ReconTypeByQuery(ReconciliationContext reconContext) {
@@ -65,11 +64,11 @@ public class ReconTypeByQuery extends ReconTypeBase {
      */
     @Override
     public ReconQueryResult querySource(int pageSize, String pagingCookie) throws SynchronizationException {
-        return query(sourceQuery.get("resourceName").asString(), 
-                sourceQuery, 
-                reconContext, 
-                Collections.synchronizedSet(new LinkedHashSet<String>()), 
-                true, 
+        return query(sourceQuery.get("resourceName").asString(),
+                sourceQuery,
+                reconContext,
+                Collections.synchronizedSet(new LinkedHashSet<String>()),
+                true,
                 QuerySide.SOURCE,
                 pageSize,
                 pagingCookie);
@@ -81,10 +80,10 @@ public class ReconTypeByQuery extends ReconTypeBase {
     @Override
     public ResultIterable queryTarget() throws SynchronizationException {
         return query(targetQuery.get("resourceName").asString(), targetQuery, reconContext,
-                Collections.synchronizedSet(new LinkedHashSet<String>()), 
+                Collections.synchronizedSet(new LinkedHashSet<String>()),
                 reconContext.getObjectMapping().getLinkType().isTargetCaseSensitive(), QuerySide.TARGET,
                 0, null
-        ).getResultIterable();                
+        ).getResultIterable();
     }
 
     /**

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SourceSyncOperation.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SourceSyncOperation.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.sync.impl;
@@ -107,6 +108,7 @@ class SourceSyncOperation extends SyncOperation {
         }
     }
 
+    @Override
     protected boolean isSourceToTarget() {
         return true;
     }
@@ -320,7 +322,6 @@ class SourceSyncOperation extends SyncOperation {
      * @return JsonValue if found, null if none
      * @throws SynchronizationException if the correlation failed.
      */
-    @SuppressWarnings("unchecked")
     private JsonValue correlateTarget(JsonValue sourceObjectOverride) throws SynchronizationException {
         JsonValue result = null;
         // TODO: consider if there are cases where this would better be lazy and not get the full target

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncMappings.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncMappings.java
@@ -20,24 +20,23 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
+import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.router.IDMConnectionFactory;
 import org.forgerock.openidm.sync.SynchronizationException;
 import org.forgerock.script.ScriptRegistry;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentException;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 
 /**
@@ -46,12 +45,9 @@ import org.osgi.service.component.ComponentException;
  * Acts as a configuration holder object for the mapping config for use by the
  * {@link SynchronizationService} and {@link ReconciliationService}.
  */
-@Component(name = SyncMappings.PID, policy = ConfigurationPolicy.OPTIONAL, immediate = true )
-@Properties({
-        @Property(name = "service.description", value = "OpenIDM object mapping service"),
-        @Property(name = "service.vendor", value = "ForgeRock AS")
-})
-@Service
+@Component(name = SyncMappings.PID, immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM object mapping service")
 public class SyncMappings implements Mappings {
     public static final String PID = "org.forgerock.openidm.sync";
 

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncMappings.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncMappings.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -68,6 +69,10 @@ public class SyncMappings implements Mappings {
     /** Script Registry service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     private volatile ScriptRegistry scriptRegistry;
+
+    void bindEnhancedConfig(EnhancedConfig enhancedConfig) {
+        this.enhancedConfig = enhancedConfig;
+    }
 
     /**
      * Activate/modify the component.  Because the List of ObjectMappings is re-assigned based on the updated

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SynchronizationService.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SynchronizationService.java
@@ -22,7 +22,7 @@ import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.resource.Requests.newQueryRequest;
 import static org.forgerock.json.resource.Requests.newReadRequest;
-import static org.forgerock.json.resource.ResourcePath.*;
+import static org.forgerock.json.resource.ResourcePath.resourcePath;
 import static org.forgerock.json.resource.Responses.newActionResponse;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 import static org.forgerock.openidm.util.ResourceUtil.notSupported;
@@ -32,51 +32,49 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.audit.events.AuditEvent;
 import org.forgerock.guava.common.base.Function;
 import org.forgerock.guava.common.base.Predicate;
 import org.forgerock.guava.common.collect.FluentIterable;
-import org.forgerock.json.resource.Connection;
-import org.forgerock.json.resource.QueryResourceHandler;
-import org.forgerock.json.resource.ResourcePath;
-import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.router.IDMConnectionFactory;
-import org.forgerock.openidm.sync.SynchronizationException;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
 import org.forgerock.json.resource.BadRequestException;
+import org.forgerock.json.resource.Connection;
 import org.forgerock.json.resource.ConnectionFactory;
 import org.forgerock.json.resource.PatchRequest;
+import org.forgerock.json.resource.QueryResourceHandler;
 import org.forgerock.json.resource.ReadRequest;
 import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
+import org.forgerock.json.resource.ResourcePath;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.SingletonResourceProvider;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
+import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.quartz.impl.ExecutionException;
 import org.forgerock.openidm.quartz.impl.ScheduledService;
+import org.forgerock.openidm.router.IDMConnectionFactory;
 import org.forgerock.openidm.sync.ReconAction;
+import org.forgerock.openidm.sync.SynchronizationException;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.AsyncFunction;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
 import org.forgerock.util.query.QueryFilter;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,14 +83,16 @@ import org.slf4j.LoggerFactory;
  * and targets listed in the synchronization mappings described by the injected Mappings.
  * Also supports invocation as a {@link ScheduledService}.
  */
-@Component(name = SynchronizationService.PID, policy = ConfigurationPolicy.IGNORE, immediate = true)
-@Properties({
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM object synchronization service"),
-    @Property(name = Constants.SERVICE_VENDOR, value = "ForgeRock AS"),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "/sync/*"),
-    @Property(name = ServerConstants.SCHEDULED_SERVICE_INVOKE_SERVICE, value = "sync")
-})
-@Service
+@Component(
+        name = SynchronizationService.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/sync/*",
+                ServerConstants.SCHEDULED_SERVICE_INVOKE_SERVICE + "=sync"
+        })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM object synchronization service")
 public class SynchronizationService implements SingletonResourceProvider, ScheduledService {
     public static final String PID = "org.forgerock.openidm.synchronization";
 

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SynchronizationService.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SynchronizationService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -118,7 +119,7 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
     protected void bindConnectionFactory(IDMConnectionFactory connectionFactory) {
     	this.connectionFactory = connectionFactory;
     }
-    
+
     public ConnectionFactory getConnectionFactory() {
         return connectionFactory;
     }
@@ -128,6 +129,10 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
 
     @Reference
     Mappings mappings;
+
+    protected void bindMappings(Mappings mappings) {
+        this.mappings = mappings;
+    }
 
     /** Enhanced configuration service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
@@ -184,6 +189,7 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
         // mappings that should be synced are those which are enabled and whose
         // source object set matches the resource container
         final Predicate<ObjectMapping> thatMatchSource = new Predicate<ObjectMapping>() {
+            @Override
             public boolean apply(ObjectMapping objectMapping) {
                 return objectMapping.isSyncEnabled()
                         && objectMapping.isSourceObject(resourceContainer, resourceId);
@@ -196,7 +202,7 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
             try {
                 if (exceptionPending == null) {
                     // No failures yet, perform sync
-                    // This operation returns a list which will contain more than one result if 
+                    // This operation returns a list which will contain more than one result if
                     // there are multiple targets to sync the source to
                     mappingResults = action.sync(context, mapping);
                 } else {
@@ -361,7 +367,7 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
             }
         } catch (ResourceException e) {
         	return e.asPromise();
-        } catch (IllegalArgumentException e) { 
+        } catch (IllegalArgumentException e) {
         	// from getActionAsEnum
         	return new BadRequestException(e.getMessage(), e).asPromise();
         } finally {

--- a/openidm-core/src/test/java/org/forgerock/openidm/managed/ManagedObjectSetTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/managed/ManagedObjectSetTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.managed;
@@ -515,7 +515,7 @@ public class ManagedObjectSetTest {
         ));
     }
 
-    @SuppressWarnings({"unchecked", "unused"})
+    @SuppressWarnings("unused")
     private <T> TestResultHandler<T> newTestResultHandler(Class<T> type) {
         return new TestResultHandler<>();
     }

--- a/openidm-core/src/test/java/org/forgerock/openidm/managed/RelationshipEqualityHashTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/managed/RelationshipEqualityHashTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.managed;
@@ -92,14 +93,14 @@ public class RelationshipEqualityHashTest {
     }
 
     private Map<String, Object> makeRefPropertiesMap(String grantType, String temporalConstraint, boolean idPresent) {
-        Map<String, Object> fieldMap = new HashMap();
+        Map<String, Object> fieldMap = new HashMap<>();
         fieldMap.put(RelationshipValidator.TEMPORAL_CONSTRAINTS, Collections.singletonList(temporalConstraint));
         fieldMap.put(RelationshipValidator.GRANT_TYPE, grantType);
         return makeRefProperties(fieldMap, idPresent);
     }
 
     private Map<String, Object> makeRefPropertiesMap(String grantType, boolean idPresent) {
-        Map<String, Object> fieldMap = new HashMap();
+        Map<String, Object> fieldMap = new HashMap<>();
         fieldMap.put(RelationshipValidator.GRANT_TYPE, grantType);
         return makeRefProperties(fieldMap, idPresent);
     }

--- a/openidm-core/src/test/java/org/forgerock/openidm/sync/impl/PolicyTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/sync/impl/PolicyTest.java
@@ -12,14 +12,15 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.sync.impl;
 
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,14 +36,14 @@ import java.util.Map;
 
 import javax.script.Bindings;
 
-import org.forgerock.services.context.Context;
-import org.forgerock.services.context.RootContext;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.sync.ReconAction;
 import org.forgerock.openidm.util.Scripts;
 import org.forgerock.script.Script;
 import org.forgerock.script.ScriptEntry;
 import org.forgerock.script.ScriptRegistry;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -59,7 +60,7 @@ public class PolicyTest {
     public void setUp() throws Exception {
         URL config = ObjectMappingTest.class.getResource("/conf/sync.json");
         Assert.assertNotNull(config, "sync configuration is not found");
-        
+
         JsonValue syncConfig = new JsonValue((new ObjectMapper()).readValue(new File(config.toURI()), Map.class));
         mappingConfig = syncConfig.get("mappings").get(0);
 
@@ -74,9 +75,9 @@ public class PolicyTest {
 
         Bindings bindingsMock = mock(Bindings.class);
         when(scriptMock.createBindings()).thenReturn(bindingsMock);
-        doNothing().when(bindingsMock).putAll(anyMapOf(String.class, Object.class));
+        doNothing().when(bindingsMock).putAll(anyMap());
         when(scriptMock.eval(bindingsMock)).thenReturn(ReconAction.IGNORE);
-        
+
     }
 
     @AfterMethod
@@ -86,7 +87,7 @@ public class PolicyTest {
 
     @Test
     public void testGetCondition() throws Exception {
-        
+
         initPolicies();
 
         assertEquals(policies.size(), 8);
@@ -116,7 +117,7 @@ public class PolicyTest {
         assertTrue(getPolicy(Situation.UNASSIGNED).getCondition()
                 .evaluate(json(object(field("linkQualifier", Link.DEFAULT_LINK_QUALIFIER))), new RootContext()));
     }
-    
+
     @Test
     public void testGetSituation() throws Exception {
 
@@ -140,7 +141,7 @@ public class PolicyTest {
         assertEquals(getPolicy(Situation.UNQUALIFIED).getSituation(), Situation.UNQUALIFIED);
 
         assertEquals(getPolicy(Situation.UNASSIGNED).getSituation(), Situation.UNASSIGNED);
-        
+
     }
 
     private void initPolicies() {
@@ -184,68 +185,68 @@ public class PolicyTest {
         LazyObjectAccessor lazyObjectAccessorTargetMock = mock(LazyObjectAccessor.class);
         when(lazyObjectAccessorTargetMock.asMap()).thenReturn(targetMap);
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.CONFIRMED)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.FOUND)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.ABSENT)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.AMBIGUOUS)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.MISSING)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.SOURCE_MISSING)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.UNQUALIFIED)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
-        assertEquals(ReconAction.IGNORE, 
+        assertEquals(ReconAction.IGNORE,
                 getPolicy(Situation.UNASSIGNED)
                         .getAction(lazyObjectAccessorSourceMock,
                                 lazyObjectAccessorTargetMock,
                                 syncOperationMock,
-                                Link.DEFAULT_LINK_QUALIFIER, 
+                                Link.DEFAULT_LINK_QUALIFIER,
                                 new RootContext()));
 
 
@@ -254,7 +255,7 @@ public class PolicyTest {
     @Test
     public void testEvaluatePostActionWithPostActionConfigured() throws Exception {
         JsonValue postAction =  null;
-        
+
         for (JsonValue jv : mappingConfig.get("policies").expect(List.class)) {
             String situation = jv.get("situation").asString();
             // capture ABSENT map for testing of postAction
@@ -270,7 +271,7 @@ public class PolicyTest {
             policies.put(situation, l);
             l.add( new Policy(jv));
         }
-        
+
         Policy pAbsent = getPolicy(Situation.ABSENT);
         assertTrue(postAction != null && !postAction.get("postAction").isNull());
 
@@ -285,7 +286,7 @@ public class PolicyTest {
         SyncOperation syncOperationMock = mock(SyncOperation.class);
         when(syncOperationMock.toJsonValue()).thenReturn(json(object()));
 
-        ReconAction absentAction = pAbsent.getAction(lazyObjectAccessorSourceMock, lazyObjectAccessorTargetMock, 
+        ReconAction absentAction = pAbsent.getAction(lazyObjectAccessorSourceMock, lazyObjectAccessorTargetMock,
                 syncOperationMock, Link.DEFAULT_LINK_QUALIFIER, new RootContext());
 
         pAbsent.evaluatePostAction(
@@ -294,7 +295,7 @@ public class PolicyTest {
                     absentAction,
                     true,
                     Link.DEFAULT_LINK_QUALIFIER,
-                    "reconId", 
+                    "reconId",
                     new RootContext());
 
     }

--- a/openidm-core/src/test/java/org/forgerock/openidm/sync/impl/ResultIterableTest.java
+++ b/openidm-core/src/test/java/org/forgerock/openidm/sync/impl/ResultIterableTest.java
@@ -12,26 +12,25 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.sync.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;   
+import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 
 import org.forgerock.json.JsonValue;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.annotations.Test;
 
-import org.forgerock.openidm.sync.impl.ResultIterable;
-
 public class ResultIterableTest {
-    
+
     @Test
     public void testRemoveWithFullObjects() throws Exception {
         int numItems = 6;
@@ -50,18 +49,18 @@ public class ResultIterableTest {
         // all other entries will be removed
         idsAsList = Arrays.asList("Id100", "Id101", "Id102", "Id103", "Id104", "Id105");
         ids = new LinkedHashSet<String>(idsAsList);
-        
+
         // Test removing the above ids
         riNew = riSource.removeNotMatchingEntries(ids);
-        
+
         // riNew should now contain all ids that we wanted to match
         assertThat(riNew.getAllIds()).containsExactlyElementsOf(idsAsList);
-        
+
         // Using full objects the resulting values should be in sync with the ids
         expectedValues = Arrays.asList("Value100", "Value101", "Value102", "Value103", "Value104", "Value105");
         assertThat(getResultIterableValues(riNew)).containsExactlyElementsOf(expectedValues);
-        
-        // Repeat the test a few times with different data 
+
+        // Repeat the test a few times with different data
         riSource = createResultIterable(numItems, true, 200);
         idsAsList = Arrays.asList("Id202", "Id203", "Id205");
         ids = new LinkedHashSet<String>(idsAsList);
@@ -69,7 +68,7 @@ public class ResultIterableTest {
         assertThat(riNew.getAllIds()).containsExactlyElementsOf(idsAsList);
         expectedValues = Arrays.asList("Value202", "Value203", "Value205");
         assertThat(getResultIterableValues(riNew)).containsExactlyElementsOf(expectedValues);
-        
+
         riSource = createResultIterable(numItems, true, 300);
         idsAsList = Arrays.asList("Id301", "Id302", "Id304");
         ids = new LinkedHashSet<String>(idsAsList);
@@ -92,23 +91,23 @@ public class ResultIterableTest {
         // false -> no full objects
         // 500 as start number for ids
         riSource = createResultIterable(numItems, false, 500);
-        
+
         // ids is the list of ids to be matched,
         // all other entries will be removed
         idsAsList = Arrays.asList("Id500", "Id501", "Id502", "Id503", "Id504", "Id505");
         ids = new LinkedHashSet<String>(idsAsList);
-        
+
         // Test removing the above ids
         riNew = riSource.removeNotMatchingEntries(ids);
-                
+
         // riNew should now contain all ids that we wanted to match
         assertThat(riNew.getAllIds()).containsExactlyElementsOf(idsAsList);
-        
+
         // If ResultIterable has no full objects the values should all be null
         expectedValues = Arrays.asList(null, null, null, null, null, null);
         assertThat(getResultIterableValues(riNew)).containsExactlyElementsOf(expectedValues);
-        
-        // Repeat the test a few times with different data 
+
+        // Repeat the test a few times with different data
         riSource = createResultIterable(numItems, false, 600);
         idsAsList = Arrays.asList("Id602", "Id603", "Id605");
         ids = new LinkedHashSet<String>(idsAsList);
@@ -116,7 +115,7 @@ public class ResultIterableTest {
         assertThat(riNew.getAllIds()).containsExactlyElementsOf(idsAsList);
         expectedValues = Arrays.asList(null, null, null);
         assertThat(getResultIterableValues(riNew)).containsExactlyElementsOf(expectedValues);
-        
+
         riSource = createResultIterable(numItems, false, 700);
         idsAsList = Arrays.asList("Id701", "Id702", "Id704");
         ids = new LinkedHashSet<String>(idsAsList);
@@ -133,7 +132,7 @@ public class ResultIterableTest {
         if (fullObject) {
             newObjList = new JsonValue(new LinkedList<>());
         }
-        
+
         for (int i = 0; i < numItems; i++) {
                 newIds.add("Id" + (startId + i));
 
@@ -145,15 +144,15 @@ public class ResultIterableTest {
 
         return new ResultIterable(newIds, newObjList);
     }
-    
+
     Collection<String> getResultIterableValues(ResultIterable ri) {
         ArrayList<String> values = new ArrayList<String>();
         Iterator<ResultEntry> it = ri.iterator();
-        
+
         while (it.hasNext()) {
             ResultEntry re = it.next();
             JsonValue jv = re.getValue();
-            
+
             if (jv == null) {
                 values.add(null);
             }

--- a/openidm-crypto/pom.xml
+++ b/openidm-crypto/pom.xml
@@ -13,7 +13,7 @@
  ~ information: "Portions copyright [year] [name of copyright owner]".
  ~
  ~ Copyright 2011-2016 ForgeRock AS.
- ~ Portions Copyright 2017-2018 Wren Security.
+ ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -51,11 +51,10 @@
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <!-- Provided Dependencies -->
+        
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -76,19 +75,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-crypto/src/main/java/org/forgerock/openidm/crypto/impl/CryptoServiceImpl.java
+++ b/openidm-crypto/src/main/java/org/forgerock/openidm/crypto/impl/CryptoServiceImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS
+ * Portions Copyright 2020 Wren Security
  */
 
 // TODO: Expose as a set of resource actions.
@@ -25,12 +26,6 @@ import static org.forgerock.json.JsonValueFunctions.identity;
 import java.io.IOException;
 import java.security.Key;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
@@ -55,7 +50,11 @@ import org.forgerock.openidm.keystore.KeyStoreService;
 import org.forgerock.openidm.util.JsonUtil;
 import org.forgerock.util.Function;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,14 +63,9 @@ import org.slf4j.LoggerFactory;
  */
 @Component(
         name = "org.forgerock.openidm.crypto",
-        immediate = true,
-        policy = ConfigurationPolicy.OPTIONAL
-)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM cryptography service"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM cryptography service")
 public class CryptoServiceImpl implements CryptoService {
 
     private final static Logger logger = LoggerFactory.getLogger(CryptoServiceImpl.class);
@@ -223,15 +217,15 @@ public class CryptoServiceImpl implements CryptoService {
 
     @Override
     public boolean isHashed(JsonValue value) {
-        return value != null 
-                &&!value.isNull() 
-                && JsonCrypto.isJsonCrypto(value) 
+        return value != null
+                &&!value.isNull()
+                && JsonCrypto.isJsonCrypto(value)
                 && value.get("$crypto").get("value").isDefined("algorithm");
     }
-    
+
     /**
      * Returns a {@link FieldStorageScheme} instance based on the supplied algorithm.
-     * 
+     *
      * @param algorithm a string representing a storage scheme algorithm
      * @return a field storage scheme implementation.
      * @throws JsonCryptoException

--- a/openidm-customendpoint/pom.xml
+++ b/openidm-customendpoint/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2012-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -73,13 +73,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -96,21 +89,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-customendpoint/src/main/java/org/forgerock/openidm/customendpoint/impl/EndpointsService.java
+++ b/openidm-customendpoint/src/main/java/org/forgerock/openidm/customendpoint/impl/EndpointsService.java
@@ -12,25 +12,26 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.customendpoint.impl;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.script.AbstractScriptedService;
+import org.forgerock.script.ScriptRegistry;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,13 +40,13 @@ import org.slf4j.LoggerFactory;
  * customize the system
  *
  */
-@Component(name = EndpointsService.PID, policy = ConfigurationPolicy.REQUIRE, metatype = true,
-        description = "OpenIDM Custom Endpoints Service", immediate = true)
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Custom Endpoints Service") ,
-    @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@Component(
+        name = EndpointsService.PID,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+//        description = "OpenIDM Custom Endpoints Service",
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Custom Endpoints Service")
 public class EndpointsService extends AbstractScriptedService {
 
     public static final String PID = "org.forgerock.openidm.endpoint";
@@ -60,6 +61,10 @@ public class EndpointsService extends AbstractScriptedService {
     /** Enhanced configuration service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     private volatile EnhancedConfig enhancedConfig;
+
+    /** Script Registry service. */
+    @Reference(policy = ReferencePolicy.DYNAMIC)
+    private volatile ScriptRegistry scriptRegistry;
 
     private ComponentContext context;
 
@@ -102,6 +107,12 @@ public class EndpointsService extends AbstractScriptedService {
         return new String[] { routerPrefix };
     }
 
+    @Override
+    protected ScriptRegistry getScriptRegistry() {
+        return scriptRegistry;
+    }
+
+    @Override
     protected BundleContext getBundleContext() {
         return context.getBundleContext();
     }

--- a/openidm-enhanced-config/pom.xml
+++ b/openidm-enhanced-config/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2015 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -69,31 +69,10 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-enhanced-config/src/main/java/org/forgerock/openidm/config/enhanced/JSONEnhancedConfig.java
+++ b/openidm-enhanced-config/src/main/java/org/forgerock/openidm/config/enhanced/JSONEnhancedConfig.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.config.enhanced;
@@ -22,22 +23,21 @@ import static org.forgerock.json.JsonValue.object;
 import java.util.Dictionary;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
 import org.forgerock.openidm.core.PropertyUtil;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.crypto.CryptoService;
+import org.forgerock.openidm.osgi.ServiceUtil;
 import org.forgerock.openidm.util.JsonUtil;
 import org.forgerock.util.Reject;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,15 +45,12 @@ import org.slf4j.LoggerFactory;
  * A service to handle enhanced configuration, including nested lists and maps
  * to represent JSON based structures.
  */
-@Component(name = JSONEnhancedConfig.PID,
-        policy = ConfigurationPolicy.IGNORE,
-        description = "OpenIDM Enhanced Config Service",
+@Component(
+        name = JSONEnhancedConfig.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
         immediate = true,
-        metatype = true)
-@Service
-@Properties(
-        @Property(name = "suppressMetatypeWarning", value = "true")
-)
+        property = Constants.SERVICE_ID + "=" + JSONEnhancedConfig.PID)
+@ServiceDescription("OpenIDM Enhanced Config Service")
 public class JSONEnhancedConfig implements EnhancedConfig {
 
     public static final String PID = "org.forgerock.openidm.config.enhanced";
@@ -79,6 +76,7 @@ public class JSONEnhancedConfig implements EnhancedConfig {
         this.cryptoService = cryptoService;
     }
 
+    @Override
     public String getConfigurationFactoryPid(ComponentContext compContext) {
         Object o = compContext.getProperties().get(ServerConstants.CONFIG_FACTORY_PID);
         if (o instanceof String) {
@@ -93,7 +91,7 @@ public class JSONEnhancedConfig implements EnhancedConfig {
         Reject.ifNull(compContext);
 
         Dictionary<String, Object> dict = compContext.getProperties();
-        String servicePid = (String) dict.get(Constants.SERVICE_PID);
+        String servicePid = ServiceUtil.getServicePid(dict);
 
         return getConfiguration(dict, compContext.getBundleContext(), servicePid);
     }

--- a/openidm-external-email/pom.xml
+++ b/openidm-external-email/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -92,13 +92,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.assertj</groupId>
@@ -127,20 +120,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/impl/EmailServiceImpl.java
+++ b/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/impl/EmailServiceImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -27,22 +28,12 @@ package org.forgerock.openidm.external.email.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.api.annotations.Action;
 import org.forgerock.api.annotations.ApiError;
 import org.forgerock.api.annotations.Handler;
 import org.forgerock.api.annotations.Operation;
 import org.forgerock.api.annotations.Schema;
 import org.forgerock.api.annotations.SingletonProvider;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
@@ -56,10 +47,18 @@ import org.forgerock.json.resource.SingletonResourceProvider;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,12 +70,15 @@ import org.slf4j.LoggerFactory;
         title = "Email Service",
         description = "Service that sends email via an external SMTP server.",
         mvccSupported = false))
-@Component(name = EmailServiceImpl.PID, immediate = true, policy = ConfigurationPolicy.REQUIRE)
-@Service
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "Outbound Email Service"),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "external/email") })
+@Component(
+        name = EmailServiceImpl.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=external/email"
+        })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Outbound Email Service")
 public class EmailServiceImpl implements SingletonResourceProvider {
     final static Logger logger = LoggerFactory.getLogger(EmailServiceImpl.class);
     public static final String PID = "org.forgerock.openidm.external.email";

--- a/openidm-external-rest/pom.xml
+++ b/openidm-external-rest/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -72,13 +72,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -121,21 +114,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-external-rest/src/main/java/org/forgerock/openidm/external/rest/RestService.java
+++ b/openidm-external-rest/src/main/java/org/forgerock/openidm/external/rest/RestService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.external.rest;
 
@@ -28,14 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.api.annotations.ApiError;
 import org.forgerock.api.annotations.Handler;
 import org.forgerock.api.annotations.Operation;
@@ -68,9 +61,9 @@ import org.forgerock.json.resource.SingletonResourceProvider;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.external.ExternalException;
 import org.forgerock.openidm.external.rest.api.CallActionRequest;
 import org.forgerock.openidm.external.rest.api.CallActionResponse;
-import org.forgerock.openidm.external.ExternalException;
 import org.forgerock.openidm.keystore.KeyStoreManagementService;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.Function;
@@ -78,8 +71,14 @@ import org.forgerock.util.Options;
 import org.forgerock.util.annotations.VisibleForTesting;
 import org.forgerock.util.encode.Base64;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,12 +90,15 @@ import org.slf4j.LoggerFactory;
         title = "External REST",
         description = "Service that acts as a HTTP client proxy to external REST services.",
         mvccSupported = false))
-@Component(name = RestService.PID, immediate = true, policy = ConfigurationPolicy.IGNORE)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "External REST Service"),
-        @Property(name = ServerConstants.ROUTER_PREFIX, value = "/external/rest")})
+@Component(
+        name = RestService.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/external/rest"
+        })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("External REST Service")
 public class RestService implements SingletonResourceProvider {
 
     static final String PID = "org.forgerock.openidm.external.rest";

--- a/openidm-felix-webconsole/pom.xml
+++ b/openidm-felix-webconsole/pom.xml
@@ -13,6 +13,7 @@
  ~ information: "Portions copyright [year] [name of copyright owner]".
  ~
  ~ Copyright 2016 ForgeRock AS.
+ ~ Portions Copyright 2020 Wren Security
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -48,12 +49,6 @@
 
         <!-- Provided OSGI Dependencies -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
@@ -87,21 +82,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-felix-webconsole/src/main/java/org/forgerock/openidm/felix/webconsole/WebConsoleSecurityProviderService.java
+++ b/openidm-felix-webconsole/src/main/java/org/forgerock/openidm/felix/webconsole/WebConsoleSecurityProviderService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.felix.webconsole;
 
@@ -67,6 +68,14 @@ public class WebConsoleSecurityProviderService implements WebConsoleSecurityProv
 
     private String userId;
     private JsonValue password;
+
+    void bindEnhancedConfig(EnhancedConfig enhancedConfig) {
+        this.enhancedConfig = enhancedConfig;
+    }
+
+    void bindCryptoService(CryptoService cryptoService) {
+        this.cryptoService = cryptoService;
+    }
 
     @Activate
     public void activate(ComponentContext context) {

--- a/openidm-felix-webconsole/src/main/java/org/forgerock/openidm/felix/webconsole/WebConsoleSecurityProviderService.java
+++ b/openidm-felix-webconsole/src/main/java/org/forgerock/openidm/felix/webconsole/WebConsoleSecurityProviderService.java
@@ -22,14 +22,6 @@ import static org.forgerock.json.JsonValue.object;
 
 import java.util.Dictionary;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.apache.felix.webconsole.WebConsoleSecurityProvider;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
@@ -37,6 +29,13 @@ import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.crypto.CryptoService;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * Creates a WebConsoleSecurityProvider service that the felix web console will use to delegate authentication attempts.
@@ -44,14 +43,9 @@ import org.osgi.service.component.ComponentContext;
 @Component(
         name = WebConsoleSecurityProviderService.PID,
         immediate = true,
-        policy = ConfigurationPolicy.REQUIRE
-)
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION,
-                value = "OpenIDM Felix Web Console Security Provider"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
-@Service
+        configurationPolicy = ConfigurationPolicy.REQUIRE)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Felix Web Console Security Provider")
 public class WebConsoleSecurityProviderService implements WebConsoleSecurityProvider {
 
     public static final String PID = "org.forgerock.openidm.felix.webconsole";

--- a/openidm-httpcontext/pom.xml
+++ b/openidm-httpcontext/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -63,12 +63,6 @@
 
         <!-- Provided Dependencies -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
@@ -83,19 +77,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-httpcontext/src/main/java/org/forgerock/openidm/http/ContextRegistrator.java
+++ b/openidm-httpcontext/src/main/java/org/forgerock/openidm/http/ContextRegistrator.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2011-2012 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -32,14 +33,14 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Reference;
 import org.ops4j.pax.web.service.WebContainer;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,10 +48,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Http context to share amongst OpenIDM servlets to allow for applying uniform
  * security handling
- * 
  */
-@Component(name = "org.forgerock.openidm.http.context", immediate = true,
-        policy = ConfigurationPolicy.IGNORE)
+@Component(
+        name = "org.forgerock.openidm.http.context",
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.IGNORE)
 public final class ContextRegistrator {
     final static Logger logger = LoggerFactory.getLogger(ContextRegistrator.class);
     public static final String OPENIDM = "openidm";
@@ -66,7 +68,7 @@ public final class ContextRegistrator {
 
     /**
      * Allow access for the fragments
-     * 
+     *
      * @return bundle context if activated, null otherwise
      */
     public static BundleContext getBundleContext() {
@@ -100,7 +102,7 @@ public final class ContextRegistrator {
 
     /**
      * Loads and instantiates the pluggable Security Configurators
-     * 
+     *
      * To allow for pluggability with fragments a simple convention is used to
      * find security configurator(s); 1. A properties file contains a property
      * security.configurator.class of a class in the bundle fragment that
@@ -162,7 +164,7 @@ public final class ContextRegistrator {
 
     /**
      * Activate security configurators if present to enable security
-     * 
+     *
      * @param context
      *            the component context of the main bundle
      * @param httpContext
@@ -177,7 +179,7 @@ public final class ContextRegistrator {
 
     /**
      * Deactivate security configurators if present to cleanup
-     * 
+     *
      * @param context
      *            the component context of the main bundle
      * @param httpContext

--- a/openidm-identity-provider/pom.xml
+++ b/openidm-identity-provider/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2016 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -41,13 +41,11 @@
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
-            <version>18.0.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
-            <version>18.0.4</version>
         </dependency>
 
         <dependency>
@@ -91,12 +89,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -125,19 +117,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-identity-provider/src/main/java/org/forgerock/openidm/idp/client/OAuthHttpClient.java
+++ b/openidm-identity-provider/src/main/java/org/forgerock/openidm/idp/client/OAuthHttpClient.java
@@ -12,10 +12,15 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.idp.client;
 
 import static org.forgerock.json.JsonValue.json;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.forgerock.http.Client;
@@ -26,6 +31,10 @@ import org.forgerock.http.protocol.Response;
 import org.forgerock.http.protocol.Responses;
 import org.forgerock.http.util.Uris;
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.common.JwtReconstruction;
+import org.forgerock.json.jose.exceptions.JwtReconstructionException;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.InternalServerErrorException;
 import org.forgerock.json.resource.NotFoundException;
@@ -33,17 +42,6 @@ import org.forgerock.json.resource.ResourceException;
 import org.forgerock.openidm.idp.config.ProviderConfig;
 import org.forgerock.util.Function;
 import org.forgerock.util.Reject;
-import org.forgerock.util.promise.NeverThrowsException;
-import org.forgerock.json.jose.common.JwtReconstruction;
-import org.forgerock.json.jose.exceptions.InvalidJwtException;
-import org.forgerock.json.jose.exceptions.JwtReconstructionException;
-import org.forgerock.json.jose.jws.SignedJwt;
-import org.forgerock.json.jose.jwt.JwtClaimsSet;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.Map;
-
 import org.forgerock.util.promise.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/openidm-identity-provider/src/main/java/org/forgerock/openidm/idp/impl/IdentityProviderConfig.java
+++ b/openidm-identity-provider/src/main/java/org/forgerock/openidm/idp/impl/IdentityProviderConfig.java
@@ -12,41 +12,41 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.idp.impl;
+
+import org.forgerock.openidm.config.enhanced.EnhancedConfig;
+import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.idp.config.ProviderConfig;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
-import org.forgerock.openidm.idp.config.ProviderConfig;
-import org.forgerock.openidm.config.enhanced.EnhancedConfig;
-import org.forgerock.openidm.core.ServerConstants;
-import org.osgi.framework.Constants;
-import org.osgi.service.component.ComponentContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A identity provider configuration holder.
  */
-@Component(name = IdentityProviderConfig.PID,
+@Component(
+        name = IdentityProviderConfig.PID,
         immediate = true,
-        policy = ConfigurationPolicy.REQUIRE,
-        configurationFactory = true)
-@Service({ IdentityProviderConfig.class })
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Identity Provider Config Service")
-})
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        // configurationFactory = true, - TODO not sure what to do about this
+        service = IdentityProviderConfig.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Identity Provider Config Service")
 public class IdentityProviderConfig {
 
     /** The PID for this Component. */
@@ -85,12 +85,12 @@ public class IdentityProviderConfig {
     }
 
     /**
-     * Returns the Identity Provider configuration
-     * as a ProviderConfig object.
+     * Returns the Identity Provider configuration as a ProviderConfig object.
      *
      * @return a ProviderConfig object
      */
     public ProviderConfig getIdentityProviderConfig() {
         return identityProviderConfig;
     }
+
 }

--- a/openidm-infoservice/pom.xml
+++ b/openidm-infoservice/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2012-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -78,13 +78,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -101,21 +94,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/health/MemoryInfoResourceProvider.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/health/MemoryInfoResourceProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.info.health;
 
@@ -20,22 +21,21 @@ import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
 import org.forgerock.api.annotations.Handler;
 import org.forgerock.api.annotations.Operation;
 import org.forgerock.api.annotations.Read;
 import org.forgerock.api.annotations.Schema;
 import org.forgerock.api.annotations.SingletonProvider;
-import org.forgerock.openidm.info.health.api.MemoryInfoResource;
-import org.forgerock.openidm.info.health.api.OsInfoResource;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.ReadRequest;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
+import org.forgerock.openidm.info.health.api.MemoryInfoResource;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
 
 /**
  * Gets Memory usage data from the {@link java.lang.management.MemoryMXBean MemoryMXBean}.

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/health/ReconInfoResourceProvider.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/health/ReconInfoResourceProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.info.health;
 
@@ -20,26 +21,26 @@ import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
 import org.forgerock.api.annotations.Handler;
 import org.forgerock.api.annotations.Operation;
 import org.forgerock.api.annotations.Read;
 import org.forgerock.api.annotations.Schema;
 import org.forgerock.api.annotations.SingletonProvider;
 import org.forgerock.json.JsonValue;
-import org.forgerock.json.resource.ReadRequest;
-import org.forgerock.openidm.info.health.api.OsInfoResource;
-import org.forgerock.openidm.info.health.api.ReconInfoResource;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.resource.InternalServerErrorException;
+import org.forgerock.json.resource.ReadRequest;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
+import org.forgerock.openidm.info.health.api.ReconInfoResource;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-import java.lang.management.ManagementFactory;
 
 /**
  * Gets Recon Health Info.

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/impl/InfoService.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/impl/InfoService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.info.impl;
 
@@ -23,14 +24,6 @@ import java.util.EnumSet;
 import javax.script.Bindings;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.Request;
 import org.forgerock.json.resource.RequestType;
@@ -39,10 +32,18 @@ import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.info.HealthInfo;
 import org.forgerock.openidm.router.IDMConnectionFactory;
 import org.forgerock.openidm.script.AbstractScriptedService;
+import org.forgerock.script.ScriptRegistry;
 import org.forgerock.services.context.Context;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,13 +51,13 @@ import org.slf4j.LoggerFactory;
  * A system information service to provide an external and internal API to query
  * OpenIDM state and status.
  */
-@Component(name = InfoService.PID, policy = ConfigurationPolicy.REQUIRE, metatype = true,
-        description = "OpenIDM Info Service", immediate = true)
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Info Service"),
-    @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@Component(
+        name = InfoService.PID,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        // description = "OpenIDM Info Service",
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Info Service")
 public class InfoService extends AbstractScriptedService {
 
     public static final String PID = "org.forgerock.openidm.info";
@@ -73,6 +74,10 @@ public class InfoService extends AbstractScriptedService {
     /** Enhanced configuration service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     private volatile EnhancedConfig enhancedConfig;
+
+    /** Script Registry service. */
+    @Reference(policy = ReferencePolicy.DYNAMIC)
+    private volatile ScriptRegistry scriptRegistry;
 
     /** The connection factory */
     @Reference(policy = ReferencePolicy.STATIC)
@@ -110,6 +115,12 @@ public class InfoService extends AbstractScriptedService {
         logger.info("OpenIDM Info Service component is deactivated.");
     }
 
+    @Override
+    protected ScriptRegistry getScriptRegistry() {
+        return scriptRegistry;
+    }
+
+    @Override
     protected BundleContext getBundleContext() {
         return context.getBundleContext();
     }

--- a/openidm-keystore/pom.xml
+++ b/openidm-keystore/pom.xml
@@ -13,7 +13,7 @@
  ~ information: "Portions copyright [year] [name of copyright owner]".
  ~
  ~ Copyright 2016 ForgeRock AS.
- ~ Portions Copyright 2017-2018 Wren Security.
+ ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -64,13 +64,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -99,20 +92,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializer.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
@@ -32,6 +33,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImpl.java
@@ -24,6 +24,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -31,18 +32,16 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509KeyManager;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.keystore.KeyStoreManagementService;
 import org.forgerock.openidm.keystore.KeyStoreService;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,13 +51,10 @@ import org.slf4j.LoggerFactory;
 @Component(
         name = KeyStoreManagementServiceImpl.PID,
         immediate = true,
-        policy = ConfigurationPolicy.IGNORE
+        configurationPolicy = ConfigurationPolicy.IGNORE
 )
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM KeyStore Management Service"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
-@Service
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM KeyStore Management Service")
 public class KeyStoreManagementServiceImpl implements KeyStoreManagementService {
 
     private static final Logger logger = LoggerFactory.getLogger(KeyStoreManagementServiceImpl.class);
@@ -72,10 +68,10 @@ public class KeyStoreManagementServiceImpl implements KeyStoreManagementService 
     private static final String HOST_ALIAS_MAPPING_REGEX = ", *(?![^\\[\\]]*\\])";
     static final String PID = "org.forgerock.openidm.keystore.impl.manager";
 
-    @Reference(target="(service.pid=" + KeyStoreServiceImpl.PID + ")")
+    @Reference(target = "(service.pid=" + KeyStoreServiceImpl.PID + ")")
     private KeyStoreService keyStore;
 
-    @Reference(target="(service.pid=" + TrustStoreServiceImpl.PID + ")")
+    @Reference(target = "(service.pid=" + TrustStoreServiceImpl.PID + ")")
     private KeyStoreService trustStore;
 
     void bindKeyStore(KeyStoreService keyStore) {

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
@@ -76,6 +77,14 @@ public class KeyStoreManagementServiceImpl implements KeyStoreManagementService 
 
     @Reference(target="(service.pid=" + TrustStoreServiceImpl.PID + ")")
     private KeyStoreService trustStore;
+
+    void bindKeyStore(KeyStoreService keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    void bindTrustStore(KeyStoreService trustStore) {
+        this.trustStore = trustStore;
+    }
 
     public void activate(@SuppressWarnings("unused") ComponentContext context) {
         reloadSslContext();

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
@@ -23,37 +24,35 @@ import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_TYPE;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
+import org.forgerock.openidm.keystore.KeyStoreService;
 import org.forgerock.openidm.util.CryptoUtil;
 import org.forgerock.security.keystore.KeyStoreType;
 import org.forgerock.util.Utils;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Component(
-        name = KeyStoreServiceImpl.PID,
-        immediate = true,
-        policy = ConfigurationPolicy.IGNORE
-)
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM KeyStore Service"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
-@Service
 /**
  * Implements a service which contains access to the openidm keystore.
  */
+@Component(
+        name = KeyStoreServiceImpl.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        property = Constants.SERVICE_PID + "=" + KeyStoreServiceImpl.PID,
+        service = KeyStoreService.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM KeyStore Service")
 public class KeyStoreServiceImpl extends AbstractKeyStoreService {
     static final String PID = "org.forgerock.openidm.keystore";
 

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/SharedKeyServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/SharedKeyServiceImpl.java
@@ -12,36 +12,37 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
 import java.security.Key;
 import java.security.KeyPair;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.crypto.JsonCryptoException;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.keystore.SharedKeyService;
 import org.forgerock.openidm.keystore.KeyStoreService;
+import org.forgerock.openidm.keystore.SharedKeyService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Shared-key Service.
  */
-@Component(name = SharedKeyServiceImpl.PID, immediate = true, policy = ConfigurationPolicy.IGNORE)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM shared-key service"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
+@Component(
+        name = SharedKeyServiceImpl.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        property = Constants.SERVICE_PID + "=" + SharedKeyServiceImpl.PID)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM shared-key service")
 public class SharedKeyServiceImpl implements SharedKeyService {
     static final String PID = "org.forgerock.openidm.keystore.sharedkey";
 

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImpl.java
@@ -12,23 +12,23 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
-import static org.forgerock.openidm.core.IdentityServer.*;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_PROVIDER;
+import static org.forgerock.openidm.core.IdentityServer.KEYSTORE_TYPE;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_LOCATION;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_PASSWORD;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_PROVIDER;
+import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_TYPE;
 import static org.forgerock.util.Utils.isNullOrEmpty;
 
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
@@ -38,19 +38,24 @@ import org.forgerock.security.keystore.KeyStoreType;
 import org.forgerock.util.Utils;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Component(
         name = TrustStoreServiceImpl.PID,
         immediate = true,
-        policy = ConfigurationPolicy.IGNORE
-)
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM TrustStore Service"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
-@Service
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        property = Constants.SERVICE_PID + "=" + TrustStoreServiceImpl.PID,
+        service = KeyStoreService.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM TrustStore Service")
 /**
  * Implements
  */

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
@@ -1,4 +1,5 @@
 /*
+
  * The contents of this file are subject to the terms of the Common Development and
  * Distribution License (the License). You may not use this file except in compliance with the
  * License.
@@ -12,7 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.keystore.impl;
@@ -36,10 +37,11 @@ import java.io.OutputStream;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Collections;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
-import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.core.IdentityServerTestUtils;
+import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
 import org.forgerock.security.keystore.KeyStoreType;
 import org.forgerock.util.Utils;
@@ -109,7 +111,6 @@ public class DefaultKeyStoreInitializerTest {
         createTrustStore(IdentityServer.getFileForPath(IdentityServer.getInstance().getProperty(TRUSTSTORE_LOCATION)));
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createKeyStore(final File keystoreFile) throws Exception {
         keystoreFile.deleteOnExit();
         if (keystoreFile.exists()) {
@@ -129,7 +130,6 @@ public class DefaultKeyStoreInitializerTest {
         }
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createTrustStore(final File keystoreFile) throws Exception {
         keystoreFile.deleteOnExit();
         if (keystoreFile.exists()) {

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreManagementServiceImplTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.keystore.impl;
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.security.KeyStore;
 import java.security.Security;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.keystore.KeyStoreDetails;

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImplTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.keystore.impl;
@@ -35,10 +35,11 @@ import java.io.OutputStream;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Collections;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
-import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.core.IdentityServerTestUtils;
+import org.forgerock.openidm.core.ServerConstants;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -79,7 +80,6 @@ public class KeyStoreServiceImplTest {
         createTrustStore(IdentityServer.getFileForPath(IdentityServer.getInstance().getProperty(TRUSTSTORE_LOCATION)));
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createKeyStore(final File keystoreFile) throws Exception {
         keystoreFile.deleteOnExit();
         if (keystoreFile.exists()) {
@@ -99,7 +99,6 @@ public class KeyStoreServiceImplTest {
         }
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createTrustStore(final File keystoreFile) throws Exception {
         keystoreFile.deleteOnExit();
         if (keystoreFile.exists()) {

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImplTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImplTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.keystore.impl;
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Collections;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.IdentityServerTestUtils;
@@ -71,7 +72,6 @@ public class TrustStoreServiceImplTest {
         createTrustStore(IdentityServer.getFileForPath(IdentityServer.getInstance().getProperty(TRUSTSTORE_LOCATION)));
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createKeyStore(final File keystoreFile) throws Exception {
         keystoreFile.deleteOnExit();
         if (keystoreFile.exists()) {
@@ -91,7 +91,6 @@ public class TrustStoreServiceImplTest {
         }
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createTrustStore(final File keystoreFile) throws Exception {
         keystoreFile.deleteOnExit();
         if (keystoreFile.exists()) {

--- a/openidm-maintenance/pom.xml
+++ b/openidm-maintenance/pom.xml
@@ -13,7 +13,7 @@
  ~ information: "Portions copyright [year] [name of copyright owner]".
  ~
  ~ Copyright 2011-2016 ForgeRock AS.
- ~ Portions Copyright 2017-2018 Wren Security.
+ ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -91,13 +91,19 @@
 
         <dependency>
             <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <artifactId>org.apache.felix.scr</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr</artifactId>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.promise</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.function</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -184,20 +190,25 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
+                                    <groupId>org.osgi</groupId>
+                                    <artifactId>org.osgi.util.promise</artifactId>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.osgi</groupId>
+                                    <artifactId>org.osgi.util.function</artifactId>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.configadmin</artifactId>
                                 </artifactItem>
-
                                 <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.log</artifactId>
                                 </artifactItem>
-
                                 <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.fileinstall</artifactId>
                                 </artifactItem>
-
                                 <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.scr</artifactId>
@@ -208,20 +219,6 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/MaintenanceFilter.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/MaintenanceFilter.java
@@ -12,16 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.impl;
 
 import java.util.regex.Pattern;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
 import org.forgerock.json.resource.CreateRequest;
@@ -41,21 +37,25 @@ import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.ServiceUnavailableException;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.filter.PassthroughFilter;
 import org.forgerock.openidm.filter.MutableFilterDecorator;
+import org.forgerock.openidm.filter.PassthroughFilter;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * Maintenance filter to disable CREST write operations while in maintenance mode.
  */
-@Component(name = MaintenanceFilter.PID, policy = ConfigurationPolicy.IGNORE, immediate = true)
-@Service({ Filter.class, MaintenanceFilter.class })
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "Product Maintenance Filter")
-})
+@Component(
+        name = MaintenanceFilter.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        service = { Filter.class, MaintenanceFilter.class })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Product Maintenance Filter")
 public class MaintenanceFilter extends MutableFilterDecorator {
 
     static final String PID = "org.forgerock.openidm.maintenance.filter";

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/MaintenanceService.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/MaintenanceService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.impl;
 
@@ -79,6 +80,10 @@ public class MaintenanceService extends AbstractRequestHandler {
      * A boolean indicating if maintenance mode is currently enabled
      */
     private final AtomicBoolean maintenanceEnabled = new AtomicBoolean(false);
+
+    void bindMaintenanceFilter(MaintenanceFilter maintenanceFilter) {
+        this.maintenanceFilter = maintenanceFilter;
+    }
 
     @Activate
     void activate(ComponentContext compContext) throws Exception {

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/MaintenanceService.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/MaintenanceService.java
@@ -23,14 +23,6 @@ import static org.forgerock.json.resource.Responses.newActionResponse;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.api.annotations.ApiError;
 import org.forgerock.api.annotations.Handler;
 import org.forgerock.api.annotations.Operation;
@@ -46,8 +38,14 @@ import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.maintenance.impl.api.CallActionResponse;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,14 +57,17 @@ import org.slf4j.LoggerFactory;
         title = "Maintenance",
         description = "Basis and entry point to initiate the product maintenance and update mechanisms over REST.",
         mvccSupported = false))
-@Component(name = MaintenanceService.PID, policy = ConfigurationPolicy.IGNORE, metatype = true,
-        description = "OpenIDM Product Upgrade Management Service", immediate = true)
-@Service({ RequestHandler.class })
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "Product Maintenance Management Service"),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "/maintenance/*")
-})
+@Component(
+        name = MaintenanceService.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM Product Upgrade Management Service",
+        immediate = true,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/maintenance/*"
+        },
+        service = RequestHandler.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Product Maintenance Management Service")
 public class MaintenanceService extends AbstractRequestHandler {
 
     static final String PID = "org.forgerock.openidm.maintenance";

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/UpdateArchiveService.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/UpdateArchiveService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.impl;
 
@@ -19,17 +20,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.AbstractRequestHandler;
 import org.forgerock.json.resource.InternalServerErrorException;
 import org.forgerock.json.resource.ReadRequest;
+import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.Responses;
@@ -39,17 +34,26 @@ import org.forgerock.openidm.maintenance.upgrade.UpdateException;
 import org.forgerock.openidm.maintenance.upgrade.UpdateManager;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
-@Component(name = UpdateArchiveService.PID, policy = ConfigurationPolicy.IGNORE, metatype = true,
-        description = "OpenIDM Product Update Archives Service", immediate = true)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "Product Update Archive Service"),
-        @Property(name = ServerConstants.ROUTER_PREFIX, value = "/maintenance/update/archives/*")
-})
+@Component(
+        name = UpdateArchiveService.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM Product Update Archives Service",
+        immediate = true,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/maintenance/update/archives/*"
+        },
+        service = RequestHandler.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Product Update Archive Service")
 public class UpdateArchiveService extends AbstractRequestHandler {
+
     public static final String PID = "org.forgerock.openidm.maintenance.update.archives";
 
     @Reference(policy= ReferencePolicy.STATIC)

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/UpdateLogServiceImpl.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/UpdateLogServiceImpl.java
@@ -21,20 +21,12 @@ import static org.forgerock.json.resource.Requests.copyOfReadRequest;
 import static org.forgerock.json.resource.Requests.newCreateRequest;
 import static org.forgerock.json.resource.ResourcePath.resourcePath;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.resource.AbstractRequestHandler;
 import org.forgerock.json.resource.QueryRequest;
 import org.forgerock.json.resource.QueryResourceHandler;
 import org.forgerock.json.resource.QueryResponse;
 import org.forgerock.json.resource.ReadRequest;
+import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourcePath;
@@ -46,22 +38,32 @@ import org.forgerock.openidm.router.IDMConnectionFactory;
 import org.forgerock.openidm.util.ContextUtil;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Endpoint for managing history of product updates.
  */
-@Component(name = UpdateLogServiceImpl.PID, policy = ConfigurationPolicy.IGNORE, metatype = true,
-        description = "OpenIDM Product Update Log Service", immediate = true)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "Product Update Log Service"),
-        @Property(name = ServerConstants.ROUTER_PREFIX, value = "/maintenance/update/log/*")
-})
+@Component(
+        name = UpdateLogServiceImpl.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM Product Update Log Service",
+        immediate = true,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/maintenance/update/log/*"
+        },
+        service = { UpdateLogService.class, RequestHandler.class })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Product Update Log Service")
 public class UpdateLogServiceImpl extends AbstractRequestHandler implements UpdateLogService {
 
     private final static Logger logger = LoggerFactory.getLogger(UpdateService.class);

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/UpdateLogServiceImpl.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/impl/UpdateLogServiceImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.impl;
 
@@ -73,6 +74,10 @@ public class UpdateLogServiceImpl extends AbstractRequestHandler implements Upda
     /** The connection factory */
     @Reference(policy = ReferencePolicy.STATIC)
     private IDMConnectionFactory connectionFactory;
+
+    void bindConnectionFactory(IDMConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
 
     @Activate
     void activate(ComponentContext compContext) throws Exception {

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/ConfigUpdater.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/ConfigUpdater.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -24,32 +25,31 @@
 
 package org.forgerock.openidm.maintenance.upgrade;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.json.JsonValue;
-import org.forgerock.openidm.router.IDMConnectionFactory;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.resource.PatchOperation;
 import org.forgerock.json.resource.PatchRequest;
 import org.forgerock.json.resource.Requests;
 import org.forgerock.json.resource.ResourceException;
-import org.osgi.framework.Constants;
+import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.router.IDMConnectionFactory;
+import org.forgerock.services.context.Context;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * Config object patching utility.
  */
-@Component(name = ConfigUpdater.PID, policy = ConfigurationPolicy.IGNORE, immediate = true,
-    description = "OpenIDM Config Update", metatype = true)
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "Config Update"),
-        @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@Component(
+        name = ConfigUpdater.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM Config Update",
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Config Update")
 public class ConfigUpdater {
     /** The PID for this component. */
     public static final String PID = "org.forgerock.openidm.maintenance.update.config";

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImpl.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImpl.java
@@ -16,10 +16,10 @@
  */
 package org.forgerock.openidm.maintenance.upgrade;
 
-import static org.forgerock.json.JsonValue.json;
-import static org.forgerock.json.JsonValue.field;
-import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.JsonValue.array;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.JsonValueFunctions.listOf;
 
 import java.io.BufferedReader;
@@ -54,20 +54,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.jar.Attributes;
 import java.util.regex.Pattern;
 
-import difflib.DiffUtils;
-import difflib.Patch;
-import net.lingala.zip4j.core.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
 import org.apache.commons.io.FileUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.commons.launcher.OSGiFrameworkService;
 import org.forgerock.guava.common.base.Strings;
 import org.forgerock.json.JsonPointer;
@@ -105,21 +92,33 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import difflib.DiffUtils;
+import difflib.Patch;
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+
 /**
  * Basic manager to initiate the product maintenance and upgrade mechanisms.
  */
-@Component(name = UpdateManagerImpl.PID, policy = ConfigurationPolicy.IGNORE, immediate = true,
-    description = "OpenIDM Update Manager", metatype = true)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "Product Update Manager"),
-        @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@Component(
+        name = UpdateManagerImpl.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM Update Manager",
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Product Update Manager")
 public class UpdateManagerImpl implements UpdateManager {
 
     /** The PID for this component. */

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImpl.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/UpdateManagerImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.upgrade;
 
@@ -180,6 +181,10 @@ public class UpdateManagerImpl implements UpdateManager {
 
     /** The OSGiFramework Service **/
     protected OSGiFrameworkService osgiFrameworkService;
+
+    void bindUpdateLogService(UpdateLogService updateLogService) {
+        this.updateLogService = updateLogService;
+    }
 
     @Activate
     void activate(ComponentContext compContext) throws Exception {
@@ -935,6 +940,7 @@ public class UpdateManagerImpl implements UpdateManager {
             this.repoUpdates = listRequiredRepoUpdates(archive, fileStateChecker);
         }
 
+        @Override
         public void run() {
             try {
                 final String projectDir = IdentityServer.getInstance().getProjectLocation().toString();

--- a/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/BundleHandlerTest.java
+++ b/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/BundleHandlerTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.upgrade;
 
@@ -195,7 +196,7 @@ public class BundleHandlerTest {
     @Test
     public void testInstallBundle() throws Exception {
         // create bundle info for installing
-        Bundle bundle = installedBundles.get(bundlePath);
+        Bundle bundle = installedBundles.get(bundlePath.toUri().toString());
 
         // check that the bundle does not exist already in the framework
         assertThat(bundle).isNull();

--- a/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/StaticFileUpdateTest.java
+++ b/openidm-maintenance/src/test/java/org/forgerock/openidm/maintenance/upgrade/StaticFileUpdateTest.java
@@ -12,13 +12,16 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.maintenance.upgrade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openidm.maintenance.upgrade.StaticFileUpdate.NEW_SUFFIX;
 import static org.forgerock.openidm.maintenance.upgrade.StaticFileUpdate.OLD_SUFFIX;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,13 +33,13 @@ import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
 import org.forgerock.util.Function;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 /**
@@ -87,7 +90,8 @@ public class StaticFileUpdateTest {
     private StaticFileUpdate getStaticFileUpdate(FileStateChecker fileStateChecker) throws IOException {
         Archive archive = mock(Archive.class);
         when(archive.getVersion()).thenReturn(newVersion);
-        when(archive.withInputStreamForPath(eq(tempFile), Matchers.<Function<InputStream, Void, IOException>>any()))
+        when(archive.withInputStreamForPath(eq(tempFile),
+                ArgumentMatchers.<Function<InputStream, Void, IOException>>any()))
                 .then(
                         new Answer<Void>() {
                             @Override

--- a/openidm-messaging/pom.xml
+++ b/openidm-messaging/pom.xml
@@ -50,12 +50,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -80,21 +74,6 @@
         <finalName>${project.artifactId}</finalName>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-messaging/src/main/java/org/forgerock/openidm/messaging/MessagingService.java
+++ b/openidm-messaging/src/main/java/org/forgerock/openidm/messaging/MessagingService.java
@@ -19,19 +19,11 @@ package org.forgerock.openidm.messaging;
 
 import static org.forgerock.guava.common.collect.FluentIterable.from;
 
-import javax.jms.Message;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
+import javax.jms.Message;
+
 import org.forgerock.guava.common.base.Function;
 import org.forgerock.guava.common.base.Predicate;
 import org.forgerock.json.JsonValue;
@@ -41,8 +33,15 @@ import org.forgerock.openidm.config.enhanced.InvalidException;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.messaging.jms.JmsMessageSubscriber;
 import org.forgerock.script.ScriptRegistry;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,12 +102,13 @@ import org.slf4j.LoggerFactory;
  * }
  * </pre>
  */
-@Component(name = MessagingService.PID, immediate = true, policy = ConfigurationPolicy.REQUIRE)
-@Service({MessagingService.class})
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Messaging Service")
-})
+@Component(
+        name = MessagingService.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        service = MessagingService.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Messaging Service")
 public class MessagingService {
     private static final Logger logger = LoggerFactory.getLogger(MessagingService.class);
 

--- a/openidm-messaging/src/main/java/org/forgerock/openidm/messaging/MessagingService.java
+++ b/openidm-messaging/src/main/java/org/forgerock/openidm/messaging/MessagingService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.messaging;
@@ -137,6 +137,14 @@ public class MessagingService {
      */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     protected volatile ScriptRegistry scriptRegistry;
+
+    void bindEnhancedConfig(EnhancedConfig enhancedConfig) {
+        this.enhancedConfig = enhancedConfig;
+    }
+
+    void bindScriptRegistry(ScriptRegistry scriptRegistry) {
+        this.scriptRegistry = scriptRegistry;
+    }
 
     /**
      * A {@link Predicate} that returns whether the subscriber is enabled

--- a/openidm-policy/pom.xml
+++ b/openidm-policy/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2012-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -66,13 +66,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -95,19 +88,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-provisioner-openicf/pom.xml
+++ b/openidm-provisioner-openicf/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright 2011-2016 ForgeRock AS.
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -111,13 +111,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.forgerock.openidm</groupId>
@@ -216,21 +209,6 @@
                         <openicfServerPort>${openicf.port}</openicfServerPort>
                     </systemPropertyVariables>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/AttributeInfoHelper.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/AttributeInfoHelper.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 package org.forgerock.openidm.provisioner.openicf.commons;
 
@@ -257,7 +257,7 @@ public class AttributeInfoHelper {
      * The {@link QueryFilterVisitor} uses this method to convert the string
      * value to a {@link Attribute} value that is used in
      * {@link org.identityconnectors.framework.common.objects.filter.Filter}
-     * 
+     *
      * @param   source
      *          The object to convert.
      *
@@ -387,14 +387,14 @@ public class AttributeInfoHelper {
     private <T> T getSingleValue(Object source, Class<T> clazz) {
         if (null == source) {
             return null;
-        } 
+        }
 
         if (source instanceof JsonValue) {
             source = ((JsonValue) source).getObject();
         }
 
         if (source instanceof List) {
-            @SuppressWarnings({ "rawtypes", "unchecked" })
+            @SuppressWarnings("rawtypes")
             List c = (List) source;
             if (c.size() < 2) {
                 if (c.isEmpty()) {
@@ -423,7 +423,7 @@ public class AttributeInfoHelper {
         if (source instanceof JsonValue) {
             source = ((JsonValue) source).getObject();
         }
-        
+
         List<T> newValues = null;
         if (source instanceof Collection) {
             newValues = new ArrayList<T>(((Collection) source).size());

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ConnectorUtil.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ConnectorUtil.java
@@ -2,7 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2016 ForgeRock AS. All Rights Reserved
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -548,7 +548,7 @@ public class ConnectorUtil {
         return result;
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked" })
+    @SuppressWarnings("rawtypes")
     public static void  configureConfigurationProperties(JsonValue source, ConfigurationProperties target,
             CryptoService cryptoService) throws JsonValueException {
         source.required();
@@ -1007,7 +1007,7 @@ public class ConnectorUtil {
      * @throws NumberFormatException
      * @throws UnsupportedOperationException
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> T coercedTypeCasting(Object source, Class<T> clazz)
     throws IllegalArgumentException {
         if (null == clazz) {
@@ -1421,6 +1421,7 @@ public class ConnectorUtil {
         final ByteArrayOutputStream clearStream = new ByteArrayOutputStream();
         GuardedByteArray.Accessor accessor = new GuardedByteArray.Accessor() {
 
+            @Override
             public void access(byte[] clearBytes) {
                 clearStream.write(clearBytes, 0, clearBytes.length);
             }
@@ -1433,6 +1434,7 @@ public class ConnectorUtil {
         final String[] clearText = new String[1];
         GuardedString.Accessor accessor = new GuardedString.Accessor() {
 
+            @Override
             public void access(char[] clearChars) {
                 clearText[0] = new String(clearChars);
             }

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderService.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderService.java
@@ -44,20 +44,10 @@ import java.util.Vector;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
-import org.forgerock.json.crypto.JsonCryptoException;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
+import org.forgerock.json.crypto.JsonCryptoException;
 import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.InternalServerErrorException;
 import org.forgerock.json.resource.NotFoundException;
@@ -86,8 +76,8 @@ import org.forgerock.util.Pair;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
 import org.forgerock.util.promise.ResultHandler;
-import org.identityconnectors.common.ConnectorKeyRange;
 import org.identityconnectors.common.CollectionUtil;
+import org.identityconnectors.common.ConnectorKeyRange;
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.Version;
 import org.identityconnectors.common.VersionRange;
@@ -105,10 +95,18 @@ import org.identityconnectors.framework.api.operations.TestApiOp;
 import org.identityconnectors.framework.common.FrameworkUtil;
 import org.identityconnectors.framework.common.exceptions.ConfigurationException;
 import org.identityconnectors.framework.common.exceptions.InvalidCredentialException;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentException;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,17 +115,13 @@ import org.slf4j.LoggerFactory;
  * href="http://openicf.forgerock.org">OpenICF</a> and makes it available as a
  * service.
  */
-@Component(name = ConnectorInfoProviderService.PID,
-        policy = ConfigurationPolicy.OPTIONAL,
-        metatype = true,
-        description = "OpenICF Connector Info Service",
+@Component(
+        name = ConnectorInfoProviderService.PID,
+        configurationPolicy = ConfigurationPolicy.OPTIONAL,
+//        description = "OpenICF Connector Info Service",
         immediate = true)
-@Service
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenICF Connector Info Service"),
-    @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenICF Connector Info Service")
 public class ConnectorInfoProviderService implements ConnectorInfoProvider, MetaDataProvider, ConnectorConfigurationHelper {
     /**
      * Setup logging for the {@link ConnectorInfoProviderService}.
@@ -160,8 +154,10 @@ public class ConnectorInfoProviderService implements ConnectorInfoProvider, Meta
     /**
      * OSGi Enabled ConnectorFrameworkFactory service.
      */
-    @Reference(referenceInterface = ConnectorFrameworkFactory.class,
-            cardinality = ReferenceCardinality.MANDATORY_UNARY, policy = ReferencePolicy.DYNAMIC)
+    @Reference(
+            service = ConnectorFrameworkFactory.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC)
     protected volatile ConnectorFrameworkFactory connectorFrameworkFactory = null;
 
     /**

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerService.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerService.java
@@ -14,7 +14,7 @@
  * "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 package org.forgerock.openidm.provisioner.openicf.impl;
 
@@ -172,6 +172,22 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
         this.activityLogger = new RouterActivityLogger(connectionFactory);
     }
 
+    void bindConnectorInfoProvider(ConnectorInfoProvider connectorInfoProvider) {
+        this.connectorInfoProvider = connectorInfoProvider;
+    }
+
+    void bindEnhancedConfig(EnhancedConfig enhancedConfig) {
+        this.enhancedConfig = enhancedConfig;
+    }
+
+    void bindRouterRegistry(RouterRegistry routerRegistry) {
+        this.routerRegistry = routerRegistry;
+    }
+
+    void bindSyncFailureHandlerFactory(SyncFailureHandlerFactory syncFailureHandlerFactory) {
+        this.syncFailureHandlerFactory = syncFailureHandlerFactory;
+    }
+
     @SuppressWarnings("unused")
     void unbindConnectionFactory(final IDMConnectionFactory connectionFactory) {
         this.connectionFactory = null;
@@ -236,6 +252,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
             final OpenICFProvisionerService provisionerService = this;
             connectorInfoProvider.findConnectorInfoAsync(connectorReference).thenOnResult(
                     new org.forgerock.util.promise.ResultHandler<ConnectorInfo>() {
+                        @Override
                         public void handleResult(ConnectorInfo connectorInfo) {
                             try {
                                 APIConfiguration config = connectorInfo.createDefaultAPIConfiguration();
@@ -568,6 +585,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
      *
      * @return  The unique system identifier.
      */
+    @Override
     public SystemIdentifier getSystemIdentifier() {
         return systemIdentifier;
     }
@@ -643,6 +661,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
      * @param context the Context of the request requesting the status
      * @return a Map of the current status of a connector
      */
+    @Override
     public Map<String, Object> getStatus(Context context) {
         Map<String, Object> result = new LinkedHashMap<>();
         JsonValue jv = new JsonValue(result);
@@ -682,6 +701,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
         return result;
     }
 
+    @Override
     public Map<String, Object> testConfig(JsonValue config) {
         JsonValue jv = json(object());
         jv.put("name", systemIdentifier.getName());
@@ -744,6 +764,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
             return null;
         }
         final Predicate<Entry<String, ObjectClassInfoHelper>> objectClassFilter = new Predicate<Entry<String, ObjectClassInfoHelper>>() {
+            @Override
             public boolean apply(Entry<String, ObjectClassInfoHelper> entry) {
                 return objectClass.equals(entry.getValue().getObjectClass());
             }
@@ -801,6 +822,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
      * @throws  org.forgerock.json.JsonValueException
      *          If the {@code previousStage} is not Map.
      */
+    @Override
     public JsonValue liveSynchronize(final Context context, final String objectType, final JsonValue previousStage)
             throws ResourceException {
 
@@ -859,6 +881,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
                                      * @throws RuntimeException If the application encounters an exception. This will
                                      * stop iteration and the exception will propagate to the application.
                                      */
+                                    @Override
                                     @SuppressWarnings("fallthrough")
                                     public boolean handle(SyncDelta syncDelta) {
                                         try {
@@ -938,18 +961,18 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
                                             try {
                                                 syncFailureHandler.invoke(context, syncFailureMap, e);
                                             } catch (SyncHandlerException syncHandlerException) {
-                                                // Current contract of the failure handler is that throwing this exception indicates 
+                                                // Current contract of the failure handler is that throwing this exception indicates
                                                 // that it should retry for this entry
                                                 syncRetry.setValue(true);
                                                 syncRetry.setThrowable(syncHandlerException);
-                                                logger.debug("Sync failure handler indicated to stop current change set processing until retry handling: {}", 
+                                                logger.debug("Sync failure handler indicated to stop current change set processing until retry handling: {}",
                                                         syncHandlerException.getMessage(), syncHandlerException);
                                             }
                                         }
 
                                         if (syncRetry.getValue()) {
                                             // Stop the processing of this result set. Next retry will start again after last token.
-                                            return false; 
+                                            return false;
                                         } else {
                                             // success (either by original sync or by failure handler)
                                             // Continue the processing of the rest of the result set

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerService.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerService.java
@@ -33,18 +33,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.guava.common.base.Predicate;
 import org.forgerock.guava.common.collect.FluentIterable;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
 import org.forgerock.json.resource.ActionRequest;
@@ -58,8 +48,8 @@ import org.forgerock.json.resource.PatchRequest;
 import org.forgerock.json.resource.ReadRequest;
 import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.Requests;
-import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.ResourceException;
+import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.ServiceUnavailableException;
 import org.forgerock.json.resource.SingletonResourceProvider;
 import org.forgerock.json.resource.UpdateRequest;
@@ -87,6 +77,7 @@ import org.forgerock.openidm.router.IDMConnectionFactory;
 import org.forgerock.openidm.router.RouteBuilder;
 import org.forgerock.openidm.router.RouteEntry;
 import org.forgerock.openidm.router.RouterRegistry;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.api.APIConfiguration;
@@ -108,9 +99,16 @@ import org.identityconnectors.framework.common.objects.SyncResultsHandler;
 import org.identityconnectors.framework.common.objects.SyncToken;
 import org.identityconnectors.framework.common.serializer.SerializerUtil;
 import org.identityconnectors.framework.impl.api.local.LocalConnectorFacadeImpl;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentException;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,17 +117,14 @@ import org.slf4j.LoggerFactory;
  * {@link CollectionResourceProvider} interface with <a
  * href="http://openicf.forgerock.org">OpenICF</a>.
  */
-@Component(name = OpenICFProvisionerService.PID,
-        policy = ConfigurationPolicy.REQUIRE,
-        metatype = true,
-        description = "OpenIDM OpenICF Provisioner Service",
-        immediate = true)
-@Service(value = {ProvisionerService.class})
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM OpenICF Provisioner Service"),
-    @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@Component(
+        name = OpenICFProvisionerService.PID,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+//        description = "OpenIDM OpenICF Provisioner Service",
+        immediate = true,
+        service = ProvisionerService.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM OpenICF Provisioner Service")
 public class OpenICFProvisionerService implements ProvisionerService, SingletonResourceProvider {
 
     // Public Constants

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/syncfailure/SyncFailureHandlerFactoryImpl.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/syncfailure/SyncFailureHandlerFactoryImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013-2015 ForgeRock, AS.
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms of the Common Development and
  * Distribution License (the License). You may not use this file except in compliance with the
@@ -15,34 +16,27 @@
  */
 package org.forgerock.openidm.provisioner.openicf.syncfailure;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
+import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.router.IDMConnectionFactory;
-import org.forgerock.json.JsonValue;
 import org.forgerock.script.ScriptRegistry;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * A factory service to create the SyncFailureHandler strategy from config.
- *
  */
-@Component(name = SyncFailureHandlerFactoryImpl.PID,
-        policy = ConfigurationPolicy.IGNORE,
-        metatype = true,
-        description = "OpenIDM Sync Failure Handler Factory Service",
+@Component(
+        name = SyncFailureHandlerFactoryImpl.PID, 
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        // description = "OpenIDM Sync Failure Handler Factory Service",
         immediate = true)
-@Service()
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Sync Failure Handler Factory"),
-    @Property(name = "suppressMetatypeWarning", value = "true")
-})
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Sync Failure Handler Factory")
 public class SyncFailureHandlerFactoryImpl implements SyncFailureHandlerFactory {
     public static final String PID = "org.forgerock.openidm.openicf.syncfailure";
 
@@ -56,14 +50,6 @@ public class SyncFailureHandlerFactoryImpl implements SyncFailureHandlerFactory 
     /** Script Registry service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     protected volatile ScriptRegistry scriptRegistry;
-
-    private void bindScriptRegistry(final ScriptRegistry service) {
-        scriptRegistry = service;
-    }
-
-    private void unbindScriptRegistry(final ScriptRegistry service) {
-        scriptRegistry = null;
-    }
 
     /** The Connection Factory */
     @Reference(policy = ReferencePolicy.STATIC)
@@ -85,6 +71,7 @@ public class SyncFailureHandlerFactoryImpl implements SyncFailureHandlerFactory 
      * @param config the config for the SyncFailureHandler
      * @return the SyncFailureHandler
      */
+    @Override
     public SyncFailureHandler create(JsonValue config) throws Exception {
 
         if (null == config || config.isNull()) {

--- a/openidm-provisioner/pom.xml
+++ b/openidm-provisioner/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -79,13 +79,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -110,20 +103,6 @@
         <finalName>${project.artifactId}</finalName>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/impl/SystemObjectSetService.java
+++ b/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/impl/SystemObjectSetService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.provisioner.impl;
 
@@ -21,23 +22,19 @@ import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.JsonValueFunctions.enumConstant;
 import static org.forgerock.json.resource.Responses.newActionResponse;
+import static org.forgerock.openidm.provisioner.ConnectorConfigurationHelper.CONFIGURATION_PROPERTIES;
 import static org.forgerock.openidm.provisioner.ConnectorConfigurationHelper.CONNECTOR_NAME;
 import static org.forgerock.openidm.provisioner.ConnectorConfigurationHelper.CONNECTOR_REF;
-import static org.forgerock.openidm.provisioner.ConnectorConfigurationHelper.CONFIGURATION_PROPERTIES;
 import static org.forgerock.util.promise.Promises.newResultPromise;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.ReferenceStrategy;
-import org.apache.felix.scr.annotations.Service;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.forgerock.audit.events.AuditEvent;
-import org.forgerock.openidm.core.PropertyUtil;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
 import org.forgerock.json.resource.ActionRequest;
@@ -55,6 +52,7 @@ import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.ServiceUnavailableException;
 import org.forgerock.json.resource.SingletonResourceProvider;
 import org.forgerock.json.resource.UpdateRequest;
+import org.forgerock.openidm.core.PropertyUtil;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.provisioner.ConnectorConfigurationHelper;
 import org.forgerock.openidm.provisioner.Id;
@@ -63,36 +61,37 @@ import org.forgerock.openidm.provisioner.SystemIdentifier;
 import org.forgerock.openidm.quartz.impl.ExecutionException;
 import org.forgerock.openidm.quartz.impl.ScheduledService;
 import org.forgerock.openidm.router.IDMConnectionFactory;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 
 /**
  * SystemObjectSetService is a {@link SingletonResourceProvider} to manage provisioner/connector configuration
  * and to dispatch liveSync to the correct provisioner implementation.
  */
-@Component(name = "org.forgerock.openidm.provisioner",
-        policy = ConfigurationPolicy.IGNORE,
-        metatype = true,
-        description = "OpenIDM System Object Set Service",
-        immediate = true)
-@Service(value = {ScheduledService.class, SingletonResourceProvider.class})
-@Properties({
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM System Object Set Service"),
-        @Property(name = ServerConstants.ROUTER_PREFIX, value = ProvisionerService.ROUTER_PREFIX),
-        @Property(name = ServerConstants.SCHEDULED_SERVICE_INVOKE_SERVICE, value = "provisioner")
-})
+@Component(
+        name = SystemObjectSetService.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM System Object Set Service",
+        immediate = true,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=" + ProvisionerService.ROUTER_PREFIX,
+                ServerConstants.SCHEDULED_SERVICE_INVOKE_SERVICE + "=provisioner"
+        },
+        service = { ScheduledService.class, SingletonResourceProvider.class })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM System Object Set Service")
 public class SystemObjectSetService implements ScheduledService, SingletonResourceProvider {
+
+    static final String PID = "org.forgerock.openidm.provisioner";
 
     private final static Logger logger = LoggerFactory.getLogger(SystemObjectSetService.class);
 
@@ -167,21 +166,18 @@ public class SystemObjectSetService implements ScheduledService, SingletonResour
         }
     }
 
-    @Reference(referenceInterface = ProvisionerService.class,
-            cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE,
-            bind = "bindProvisionerService",
-            unbind = "unbindProvisionerService",
-            policy = ReferencePolicy.DYNAMIC,
-            strategy = ReferenceStrategy.EVENT)
-    private Map<SystemIdentifier, ProvisionerService> provisionerServices = new HashMap<SystemIdentifier, ProvisionerService>();
+    private Map<SystemIdentifier, ProvisionerService> provisionerServices = new ConcurrentHashMap<>();
 
-    @SuppressWarnings("rawtypes")
-    protected void bindProvisionerService(ProvisionerService service, Map properties) {
+    @Reference(
+            service = ProvisionerService.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            unbind = "unbindProvisionerService",
+            policy = ReferencePolicy.DYNAMIC)
+    protected void bindProvisionerService(ProvisionerService service, Map<String, Object> properties) {
         provisionerServices.put(service.getSystemIdentifier(), service);
     }
 
-    @SuppressWarnings("rawtypes")
-    protected void unbindProvisionerService(ProvisionerService service, Map properties) {
+    protected void unbindProvisionerService(ProvisionerService service, Map<String, Object> properties) {
         for (Map.Entry<SystemIdentifier, ProvisionerService> entry : provisionerServices.entrySet()) {
             if (service.equals(entry.getValue())) {
                 provisionerServices.remove(entry.getKey());
@@ -198,20 +194,18 @@ public class SystemObjectSetService implements ScheduledService, SingletonResour
         this.connectionFactory = connectionFactory;
     }
 
-    @Reference(referenceInterface = ConnectorConfigurationHelper.class,
-            cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE,
-            bind = "bindConnectorConfigurationHelper",
+    private Map<String, ConnectorConfigurationHelper> connectorConfigurationHelpers = new ConcurrentHashMap<>();
+
+    @Reference(
+            service = ConnectorConfigurationHelper.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
             unbind = "unbindConnectorConfigurationHelper",
             policy = ReferencePolicy.DYNAMIC)
-    private Map<String, ConnectorConfigurationHelper> connectorConfigurationHelpers = new HashMap<String, ConnectorConfigurationHelper>();
-
-    @SuppressWarnings("rawtypes")
-    protected void bindConnectorConfigurationHelper(ConnectorConfigurationHelper helper, Map properties) throws ResourceException {
+    protected void bindConnectorConfigurationHelper(ConnectorConfigurationHelper helper, Map<String, Object> properties) throws ResourceException {
         connectorConfigurationHelpers.put(helper.getProvisionerType(), helper);
     }
 
-    @SuppressWarnings("rawtypes")
-    protected void unbindConnectorConfigurationHelper(ConnectorConfigurationHelper helper, Map properties) {
+    protected void unbindConnectorConfigurationHelper(ConnectorConfigurationHelper helper, Map<String, Object> properties) {
         connectorConfigurationHelpers.remove(helper.getProvisionerType());
     }
 
@@ -236,7 +230,9 @@ public class SystemObjectSetService implements ScheduledService, SingletonResour
                 }
             }
 
-            final ConnectorConfigurationHelper helper = connectorConfigurationHelpers.get(provisionerType);
+            final ConnectorConfigurationHelper helper = provisionerType != null
+                    ? connectorConfigurationHelpers.get(provisionerType)
+                    : null;
 
             switch (action) {
             case createConfiguration:
@@ -397,6 +393,7 @@ public class SystemObjectSetService implements ScheduledService, SingletonResour
      *          if execution of the scheduled work failed.
      *          Implementations can also throw RuntimeExceptions which will get logged.
      */
+    @Override
     public void execute(Context context, Map<String, Object> schedulerContext) throws ExecutionException {
         try {
             JsonValue params = new JsonValue(schedulerContext).get(CONFIGURED_INVOKE_CONTEXT);

--- a/openidm-repo-jdbc/pom.xml
+++ b/openidm-repo-jdbc/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -99,12 +99,6 @@
 
         <!-- Provided Dependencies -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.jolbox</groupId>
             <artifactId>bonecp</artifactId>
             <version>0.7.1.RELEASE</version>
@@ -184,21 +178,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
 
@@ -208,12 +187,13 @@
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Bundle-Activator>org.forgerock.openidm.repo.jdbc.impl.Activator</Bundle-Activator>
                         <Embed-Dependency>HikariCP;bonecp;guava;scope=provided</Embed-Dependency>
-
                         <Import-Package>
                             com.codahale.metrics.*;resolution:=optional,
                             io.prometheus.client.*;resolution:=optional,
                             javassist.*;resolution:=optional,
                             org.hibernate.*;resolution:=optional,
+                            com.google.appengine.api.*;resolution:=optional,
+                            com.google.apphosting.api.*;resolution:=optional,
                             *
                         </Import-Package>
                     </instructions>

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/datasource/jdbc/impl/JDBCDataSourceService.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/datasource/jdbc/impl/JDBCDataSourceService.java
@@ -12,16 +12,36 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.datasource.jdbc.impl;
 
 import static com.fasterxml.jackson.core.Version.unknownVersion;
 
-import javax.sql.DataSource;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.forgerock.json.JsonValue;
+import org.forgerock.openidm.config.enhanced.EnhancedConfig;
+import org.forgerock.openidm.core.ServerConstants;
+import org.forgerock.openidm.datasource.DataSourceService;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -32,25 +52,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.zaxxer.hikari.HikariConfig;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
-import org.forgerock.json.JsonValue;
-import org.forgerock.openidm.config.enhanced.EnhancedConfig;
-import org.forgerock.openidm.datasource.DataSourceService;
-import org.forgerock.openidm.core.ServerConstants;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.service.component.ComponentContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A DataSource Manager for JDBC DataSources.
@@ -58,13 +59,13 @@ import org.slf4j.LoggerFactory;
  * This service exposes a DataSourceService for based on JDBC DataSource configuration.  DataSources through
  * JDNI, OSGi service-registration, non-pooled connections, and BoneCP are supported.
  */
-@Component(name = JDBCDataSourceService.PID, immediate = true, policy = ConfigurationPolicy.REQUIRE,
-        configurationFactory = true, enabled = true)
-@Service
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "DataSource Service using JDBC"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
+@Component(
+        name = JDBCDataSourceService.PID,
+        immediate = true,
+        // configurationFactory = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("DataSource Service using JDBC")
 public class JDBCDataSourceService implements DataSourceService {
     public static final String PID = "org.forgerock.openidm.datasource.jdbc";
 

--- a/openidm-repo-orientdb/pom.xml
+++ b/openidm-repo-orientdb/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -144,12 +144,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.assertj</groupId>
@@ -180,20 +174,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/impl/DocumentUtil.java
+++ b/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/impl/DocumentUtil.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -46,21 +47,21 @@ import static org.forgerock.json.JsonValue.json;
 
 /**
  * A utility class for handling and converting OrientDB ODocuments
- * 
+ *
  */
 public class DocumentUtil  {
     final static Logger logger = LoggerFactory.getLogger(DocumentUtil.class);
-    
-    // Identifiers in the object model. 
-    // TDOO: replace with common definitions of these global variables 
+
+    // Identifiers in the object model.
+    // TDOO: replace with common definitions of these global variables
     public final static String TAG_ID = "_id";
     public final static String TAG_REV = "_rev";
-    
+
     // Identifier in the DB representation
     public final static String ORIENTDB_PRIMARY_KEY = "_openidm_id";
 
     public final static String ORIENTDB_VERSION_KEY = "version";
-    
+
     /**
      * Convert to JSON object structures (akin to simple binding), composed of
      * the basic Java types: {@link Map}, {@link List}, {@link String},
@@ -68,7 +69,7 @@ public class DocumentUtil  {
      *
      * @param doc
      *            the OrientDB document to convert
-     * @return the Resource with the id, rev, and the doc converted into maps, lists, 
+     * @return the Resource with the id, rev, and the doc converted into maps, lists,
      *         java types; or null if the doc was null
      */
     public static ResourceResponse toResource(ODocument doc) {
@@ -81,9 +82,9 @@ public class DocumentUtil  {
         }
         return result;
     }
-    
+
     /**
-     * Convert to JSON object structures (akin to simple binding), 
+     * Convert to JSON object structures (akin to simple binding),
      * composed of the basic Java types: {@link Map}, {@link List}, {@link String}, {@link Number}, {@link Boolean}.
      * @param doc the OrientDB document to convert
      * @return the doc converted into maps, lists, java types; or null if the doc was null
@@ -93,18 +94,18 @@ public class DocumentUtil  {
     }
 
     /**
-     * Convert to JSON object structures (akin to simple binding), 
+     * Convert to JSON object structures (akin to simple binding),
      * composed of the basic Java types: {@link Map}, {@link List}, {@link String}, {@link Number}, {@link Boolean}.
      * This may change the objects in the passed doc, it is not safe to use doc contents after calling this method.
-     * 
+     *
      * @param doc the OrientDB document to convert
      * @param topLevel if the passed in document represents a top level orientdb class, or false if it is an embedded document
      * @return the doc converted into maps, lists, java types; or null if the doc was null
      */
-    private static Map<String, Object> toMap(ODocument doc, boolean topLevel) {        
+    private static Map<String, Object> toMap(ODocument doc, boolean topLevel) {
         Map<String, Object> result = null;
         if (doc != null) {
-            result = new LinkedHashMap<String, Object>(); // TODO: As JSON doesn't, do we really want to maintain order?   
+            result = new LinkedHashMap<String, Object>(); // TODO: As JSON doesn't, do we really want to maintain order?
             for (java.util.Map.Entry<String, Object> entry : doc) {
                 Object value = entry.getValue();
                 String key = entry.getKey();
@@ -121,7 +122,7 @@ public class DocumentUtil  {
                     logger.trace("Setting revision to {}", value.toString());
                     result.put(TAG_REV, value.toString());
                 } else {
-                    // TODO: optimization switch: if we know that no embedded ODocuments are used 
+                    // TODO: optimization switch: if we know that no embedded ODocuments are used
                     // (i.e. only embedded Maps, Lists) then we would not need to traverse the whole graph
                     value = asSimpleBinding(value);
                     logger.trace("Map setting {} to value {}", key, value);
@@ -132,15 +133,15 @@ public class DocumentUtil  {
         logger.trace("Converted document {} to {}", doc, result);
         return result;
     }
-    
+
     /**
      * Recursively ensure that the passed type is represented
      * or converted to JSON object model simple binding types,
-     * i.e. ODocument to Map, Set to List 
-     * 
-     * Modifies the passed in objToClean where possible (List, Map), 
+     * i.e. ODocument to Map, Set to List
+     *
+     * Modifies the passed in objToClean where possible (List, Map),
      * returns new types where it is not (ODocument, Set)
-     * 
+     *
      * @param objToClean the object to clean/bind
      * @return the object in JSON object model representation
      */
@@ -148,7 +149,7 @@ public class DocumentUtil  {
     private static Object asSimpleBinding(Object objToClean) {
         if (objToClean instanceof ODocument) {
             logger.trace("Converting embedded ODocument {} to map ", objToClean);
-            return DocumentUtil.toMap((ODocument) objToClean, false); 
+            return DocumentUtil.toMap((ODocument) objToClean, false);
         } else if (objToClean instanceof List) {
             logger.trace("Checking embedded list {} ", objToClean);
             return toSimpleModel((List) objToClean);
@@ -166,9 +167,9 @@ public class DocumentUtil  {
             return objToClean;
         }
     }
-    
+
     /**
-     * Iteratively convert contents as necessary to simple model 
+     * Iteratively convert contents as necessary to simple model
      * @param listToClean list to modify if necessary
      * @return the modified list
      */
@@ -179,17 +180,17 @@ public class DocumentUtil  {
             Object listEntry = listIter.next();
             if (listEntry instanceof ODocument || listEntry instanceof Set) {
                 // Replace the entry with new type
-                listIter.set(asSimpleBinding(listEntry)); 
+                listIter.set(asSimpleBinding(listEntry));
             } else {
                 // Replace directly in the entry
                 asSimpleBinding(listEntry);
-            } 
+            }
         }
         return listToClean;
     }
 
     /**
-     * Iteratively convert contents as necessary to simple model 
+     * Iteratively convert contents as necessary to simple model
      * @param setToClean set to convert to List and modify if necessary
      * @return the modified list
      */
@@ -204,20 +205,20 @@ public class DocumentUtil  {
     }
 
     /**
-     * Iteratively convert contents as necessary to simple model 
+     * Iteratively convert contents as necessary to simple model
      * @param mapToClean map to modify if necessary
      * @return the modified map
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings("rawtypes")
     private static Map toSimpleModel(Map<String, Object> mapToClean) {
         for(Map.Entry<String, Object> entry : mapToClean.entrySet()) {
             entry.setValue(asSimpleBinding(entry.getValue()));
         }
         return mapToClean;
-    }    
-    
+    }
+
     /**
-     * Convert from JSON object structures (akin to simple binding), 
+     * Convert from JSON object structures (akin to simple binding),
      * composed of the basic Java types: {@link Map}, {@link List}, {@link String}, {@link Number}, {@link Boolean}.
      * to OrientDB document
      * @param objModel the JSON object structure to convert
@@ -231,9 +232,9 @@ public class DocumentUtil  {
             throws ConflictException {
         return toDocument(objModel.asMap(), docToPopulate, db, orientDocClass, false, true);
     }
-    
+
     /**
-     * Convert from JSON object structures (akin to simple binding), 
+     * Convert from JSON object structures (akin to simple binding),
      * composed of the basic Java types: {@link Map}, {@link List}, {@link String}, {@link Number}, {@link Boolean}.
      * to OrientDB document
      * @param objModel the JSON object structure to convert
@@ -247,24 +248,24 @@ public class DocumentUtil  {
             throws ConflictException {
         return toDocument(objModel, docToPopulate, db, orientDocClass, false, true);
     }
-    
+
     /**
-     * Convert from JSON object structures (akin to simple binding), 
+     * Convert from JSON object structures (akin to simple binding),
      * composed of the basic Java types: {@link Map}, {@link List}, {@link String}, {@link Number}, {@link Boolean}.
      * to OrientDB document
      * @param objModel the JSON object structure to convert
      * @param docToPopulate an optional existing ODocument to update with new values from {@code objModel}
      * @param db the database to associate with the ODocument
      * @param orientDocClass the OrientDB class of the ODocument to create
-     * @param patch whether the objModel passed in is only partial values (replacing and adding values), 
+     * @param patch whether the objModel passed in is only partial values (replacing and adding values),
      * or if false replaces the whole document with the given {@code objModel}
      * @param topLevel
      * @return the converted orientdb document, or null if objModel was null
      * @throws ConflictException when the revision in the Object model is invalid
      */
-    protected static ODocument toDocument(Map<String, Object> objModel, ODocument docToPopulate, ODatabaseDocumentTx db, String orientDocClass, boolean patch, 
+    protected static ODocument toDocument(Map<String, Object> objModel, ODocument docToPopulate, ODatabaseDocumentTx db, String orientDocClass, boolean patch,
             boolean topLevel) throws ConflictException {
-        
+
         ODocument result = null;
         if (objModel != null) {
             if (docToPopulate == null) {
@@ -294,7 +295,7 @@ public class DocumentUtil  {
                 if (entry.getKey().equals(TAG_ID)) {
                     // OpenIDM ID mapping
                     if (topLevel) {
-                        if (!result.containsField(ORIENTDB_PRIMARY_KEY) 
+                        if (!result.containsField(ORIENTDB_PRIMARY_KEY)
                                 || !result.field(ORIENTDB_PRIMARY_KEY).equals(value)) {
                             logger.trace("Setting primary key to {}", value);
                             result.field(ORIENTDB_PRIMARY_KEY, value);
@@ -339,7 +340,7 @@ public class DocumentUtil  {
                     //necessary for fields which contain '.'. See javadocs for ODocument.field for details
                     existingDoc.setAllowChainedAccess(false);
 
-                    //} 
+                    //}
                     ODocument converted = toDocument(json(value).asMap(), existingDoc, db, null, patch, false);
                     result.field(entry.getKey(), converted, OType.EMBEDDED);
                 } else {
@@ -358,12 +359,12 @@ public class DocumentUtil  {
      * @return the OrientDB version
      * @throws ConflictException if the revision String could not be parsed into the int expected by OrientDB
      */
-    public static int parseVersion(String revision) throws ConflictException { 
+    public static int parseVersion(String revision) throws ConflictException {
         int ver = -1;
         try {
             ver = Integer.parseInt(revision);
         } catch (NumberFormatException ex) {
-            throw new ConflictException("OrientDB repository expects revisions as int, " 
+            throw new ConflictException("OrientDB repository expects revisions as int, "
                     + "unable to parse passed revision: " + revision);
         }
         return ver;

--- a/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/impl/OrientDBRepoService.java
+++ b/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/impl/OrientDBRepoService.java
@@ -12,12 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 package org.forgerock.openidm.repo.orientdb.impl;
 
 import static org.forgerock.json.resource.CountPolicy.EXACT;
-import static org.forgerock.json.resource.CountPolicy.NONE;
 import static org.forgerock.json.resource.QueryResponse.NO_COUNT;
 import static org.forgerock.json.resource.ResourceException.newResourceException;
 import static org.forgerock.json.resource.Responses.newActionResponse;
@@ -32,18 +31,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
-import org.forgerock.openidm.router.IDMConnectionFactory;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
 import org.forgerock.json.resource.ActionRequest;
@@ -64,8 +51,8 @@ import org.forgerock.json.resource.QueryResponse;
 import org.forgerock.json.resource.ReadRequest;
 import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.Requests;
-import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.ResourceException;
+import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.IdentityServer;
@@ -76,9 +63,20 @@ import org.forgerock.openidm.repo.RepositoryService;
 import org.forgerock.openidm.repo.orientdb.impl.query.Commands;
 import org.forgerock.openidm.repo.orientdb.impl.query.PredefinedQueries;
 import org.forgerock.openidm.repo.orientdb.impl.query.Queries;
+import org.forgerock.openidm.router.IDMConnectionFactory;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.Reject;
 import org.forgerock.util.promise.Promise;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,12 +92,16 @@ import com.orientechnologies.orient.core.version.OSimpleVersion;
 /**
  * Repository service implementation using OrientDB
  */
-@Component(name = OrientDBRepoService.PID, immediate=true, policy=ConfigurationPolicy.REQUIRE, enabled=true)
-@Service (value = {RepositoryService.class, RequestHandler.class}) // Omit the RepoBootService interface from the managed service
-@Properties({
-    @Property(name = "service.description", value = "Repository Service using OrientDB"),
-    @Property(name = "service.vendor", value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "/repo/*") }) // "/repo/{partition}*") })
+@Component(
+        name = OrientDBRepoService.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/repo/*"
+        },
+        service = { RepositoryService.class, RequestHandler.class })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Repository Service using OrientDB")
 public class OrientDBRepoService implements RequestHandler, RepositoryService, RepoBootService {
 
     final static Logger logger = LoggerFactory.getLogger(OrientDBRepoService.class);

--- a/openidm-router/pom.xml
+++ b/openidm-router/pom.xml
@@ -13,7 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2011-2016 ForgeRock AS.
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -74,13 +74,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.forgerock.commons</groupId>
@@ -108,20 +101,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/RouteBuilder.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/RouteBuilder.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2013-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2020 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -203,7 +204,7 @@ public final class RouteBuilder {
         return this;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings("unchecked")
     public RouteMatcher<Request>[] register(Router router) {
         if (routes.isEmpty()) {
             return new RouteMatcher[0];

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/impl/JsonResourceRouterService.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/impl/JsonResourceRouterService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.router.impl;
@@ -21,15 +22,6 @@ import static org.forgerock.services.context.ClientContext.newInternalClientCont
 
 import java.util.List;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.http.header.MalformedHeaderException;
 import org.forgerock.http.header.TransactionIdHeader;
 import org.forgerock.json.resource.AbstractConnectionWrapper;
@@ -46,6 +38,14 @@ import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,13 +68,17 @@ import org.slf4j.LoggerFactory;
  * endpoints to authenticated users that relay (or proxy) requests to other parts of the system where
  * we want to apply the same business logic as if these requests had been directly over HTTP.
  */
-@Component(name = JsonResourceRouterService.PID, policy = ConfigurationPolicy.IGNORE,
-        metatype = true, configurationFactory = false, immediate = true)
-@Service(value = { ConnectionFactory.class, IDMConnectionFactory.class })
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM internal JSON resource router"),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "/") })
+@Component(
+        name = JsonResourceRouterService.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        immediate = true,
+        service = { ConnectionFactory.class, IDMConnectionFactory.class },
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/",
+                Constants.SERVICE_PID + "=" + JsonResourceRouterService.PID
+        })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM internal JSON resource router")
 public class JsonResourceRouterService implements IDMConnectionFactory {
 
     // Public Constants

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/impl/RouterConfig.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/impl/RouterConfig.java
@@ -17,7 +17,8 @@
 
 package org.forgerock.openidm.router.impl;
 
-import static org.forgerock.json.JsonValueFunctions.*;
+import static org.forgerock.json.JsonValueFunctions.enumConstant;
+import static org.forgerock.json.JsonValueFunctions.pattern;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -30,15 +31,6 @@ import javax.script.ScriptException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
@@ -50,15 +42,22 @@ import org.forgerock.json.resource.Request;
 import org.forgerock.json.resource.RequestType;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
-import org.forgerock.openidm.router.RouterFilterRegistration;
 import org.forgerock.openidm.filter.ScriptedFilter;
-import org.forgerock.openidm.util.JsonUtil;
+import org.forgerock.openidm.router.RouterFilterRegistration;
 import org.forgerock.script.Script;
 import org.forgerock.script.ScriptEntry;
 import org.forgerock.script.ScriptRegistry;
 import org.forgerock.services.context.Context;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,12 +65,12 @@ import org.slf4j.LoggerFactory;
  * A config object holder to manage the router configuration, including the list of CREST router {@link Filter}s
  * to be added to the {@link FilterChain} managed by the {@link RouterFilterRegistration} service.
  */
-@Component(name = RouterConfig.PID, policy = ConfigurationPolicy.REQUIRE,
-        configurationFactory = false, immediate = true)
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Router Config")
-})
+@Component(
+        name = RouterConfig.PID,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        immediate = true)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Router Config")
 public class RouterConfig {
 
     static final String PID = "org.forgerock.openidm.router";

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/impl/RouterConfig.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/impl/RouterConfig.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.router.impl;
@@ -95,6 +96,10 @@ public class RouterConfig {
 
     /** the component configuration */
     private JsonValue config;
+
+    void bindScriptRegistry(ScriptRegistry scriptRegistry) {
+        this.scriptRegistry = scriptRegistry;
+    }
 
     @Activate
     protected void activate(ComponentContext context) {

--- a/openidm-scheduler/pom.xml
+++ b/openidm-scheduler/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -96,13 +96,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.forgerock.commons</groupId>
@@ -131,21 +124,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-scheduler/src/main/java/org/forgerock/openidm/scheduler/JobRequestHandler.java
+++ b/openidm-scheduler/src/main/java/org/forgerock/openidm/scheduler/JobRequestHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.scheduler;
 
@@ -34,7 +35,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -69,12 +69,10 @@ import org.forgerock.openidm.filter.JsonValueFilterVisitor;
 import org.forgerock.openidm.quartz.impl.ScheduledService;
 import org.forgerock.openidm.quartz.impl.SchedulerServiceJob;
 import org.forgerock.openidm.quartz.impl.StatefulSchedulerServiceJob;
-import org.forgerock.openidm.scheduler.impl.TriggerFactory;
 import org.forgerock.openidm.util.JsonUtil;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.query.QueryFilter;
-import org.quartz.CronTrigger;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;

--- a/openidm-scheduler/src/main/java/org/forgerock/openidm/scheduler/ScheduleConfigService.java
+++ b/openidm-scheduler/src/main/java/org/forgerock/openidm/scheduler/ScheduleConfigService.java
@@ -12,35 +12,39 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.scheduler;
 
 import java.text.ParseException;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.config.enhanced.InvalidException;
+import org.forgerock.openidm.osgi.ServiceUtil;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Schedule Config Service
- *
  */
-
-@Component(name = "org.forgerock.openidm.schedule", immediate=true, policy=ConfigurationPolicy.REQUIRE, configurationFactory=true)
+@Component(
+        name = "org.forgerock.openidm.schedule",
+        immediate = true,
+//        configurationFactory = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class ScheduleConfigService {
 
     final static Logger logger = LoggerFactory.getLogger(ScheduleConfigService.class);
@@ -73,7 +77,7 @@ public class ScheduleConfigService {
         if (configFactoryPID != null) {
             jobName = configFactoryPID;
         } else {
-            jobName = (String) compContext.getProperties().get(Constants.SERVICE_PID);
+            jobName = ServiceUtil.getServicePid(compContext.getProperties());
         }
 
         schedulerService.registerConfigService(this);

--- a/openidm-scheduler/src/main/java/org/forgerock/openidm/scheduler/SchedulerService.java
+++ b/openidm-scheduler/src/main/java/org/forgerock/openidm/scheduler/SchedulerService.java
@@ -14,15 +14,18 @@
  * "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 package org.forgerock.openidm.scheduler;
 
 import static org.forgerock.http.routing.RoutingMode.STARTS_WITH;
-import static org.forgerock.json.JsonValue.*;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.resource.Responses.newActionResponse;
 import static org.forgerock.openidm.scheduler.JobRequestHandler.JOB_RESOURCE_PATH;
-import static org.forgerock.openidm.scheduler.RepoProxyRequestHandler.*;
+import static org.forgerock.openidm.scheduler.RepoProxyRequestHandler.ACQUIRED_TRIGGERS_RESOURCE_PATH;
+import static org.forgerock.openidm.scheduler.RepoProxyRequestHandler.WAITING_TRIGGERS_RESOURCE_PATH;
 import static org.forgerock.openidm.scheduler.TriggerRequestHandler.TRIGGER_RESOURCE_PATH;
 import static org.quartz.CronExpression.isValidExpression;
 
@@ -31,15 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
@@ -66,8 +60,15 @@ import org.forgerock.openidm.router.RouteService;
 import org.forgerock.openidm.util.ContextUtil;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.quartz.Job;
 import org.quartz.ObjectAlreadyExistsException;
 import org.quartz.SchedulerException;
@@ -82,13 +83,16 @@ import org.slf4j.LoggerFactory;
  * Scheduler service using Quartz. This service exposes subroutes for the Quartz resources ({@link Trigger Triggers},
  * {@link Job Jobs})
  */
-@Component(name = "org.forgerock.openidm.scheduler", immediate=true, policy=ConfigurationPolicy.REQUIRE)
-@Service(value = {SchedulerService.class, RequestHandler.class})
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "Scheduler Service using Quartz"),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "/scheduler*")
-})
+@Component(
+        name = "org.forgerock.openidm.scheduler",
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/scheduler*"
+        },
+        service = { SchedulerService.class, RequestHandler.class })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Scheduler Service using Quartz")
 public class SchedulerService implements RequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(SchedulerService.class);
 

--- a/openidm-script/pom.xml
+++ b/openidm-script/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2012 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -89,12 +89,6 @@
 
         <!-- Provided Dependencies -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.ops4j.pax.swissbox</groupId>
             <artifactId>pax-swissbox-extender</artifactId>
             <version>1.8.2</version>
@@ -131,20 +125,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-script/src/main/java/org/forgerock/openidm/script/ScriptedPatchValueTransformerFactory.java
+++ b/openidm-script/src/main/java/org/forgerock/openidm/script/ScriptedPatchValueTransformerFactory.java
@@ -20,7 +20,6 @@ package org.forgerock.openidm.script;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.*;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.BadRequestException;
@@ -31,7 +30,12 @@ import org.forgerock.openidm.patch.ScriptedPatchValueTransformer;
 import org.forgerock.script.ScriptEntry;
 import org.forgerock.script.ScriptRegistry;
 import org.forgerock.services.context.Context;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * A factory API that enables callers to obtain a ScriptRegistryService based transformer given context.
@@ -39,13 +43,10 @@ import org.osgi.framework.Constants;
 @Component(
         name = ScriptedPatchValueTransformerFactory.PID,
         immediate = true,
-        policy = ConfigurationPolicy.IGNORE
-)
-@Properties({
-        @Property(name = Constants.SERVICE_DESCRIPTION, value = "OpenIDM Scripted Patch Value Transformer Factory"),
-        @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME)
-})
-@Service({ ScriptedPatchValueTransformerFactory.class })
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        service = ScriptedPatchValueTransformerFactory.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM Scripted Patch Value Transformer Factory")
 public class ScriptedPatchValueTransformerFactory {
     /** The PID for this Component. */
     public static final String PID = "org.forgerock.openidm.script.ScriptedPatchValueTransformerFactory";

--- a/openidm-script/src/main/java/org/forgerock/openidm/script/ScriptedPatchValueTransformerFactory.java
+++ b/openidm-script/src/main/java/org/forgerock/openidm/script/ScriptedPatchValueTransformerFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.script;
@@ -56,6 +57,14 @@ public class ScriptedPatchValueTransformerFactory {
     /** Script Executor service. */
     @Reference(policy = ReferencePolicy.DYNAMIC)
     private volatile ScriptExecutor scriptExecutor = null;
+
+    void bindScriptExecutor(ScriptExecutor scriptExecutor) {
+        this.scriptExecutor = scriptExecutor;
+    }
+
+    void bindScriptRegistry(ScriptRegistry scriptRegistry) {
+        this.scriptRegistry = scriptRegistry;
+    }
 
     /**
      * The method returns a ScriptRegistryService based transformer.

--- a/openidm-script/src/test/java/org/forgerock/openidm/script/ScriptedPatchValueTransformerFactoryTest.java
+++ b/openidm-script/src/test/java/org/forgerock/openidm/script/ScriptedPatchValueTransformerFactoryTest.java
@@ -12,13 +12,23 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.script;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.PatchOperation;
-import org.forgerock.openidm.script.ScriptExecutor;
 import org.forgerock.openidm.script.impl.ScriptRegistryService;
 import org.forgerock.script.engine.ScriptEngineFactory;
 import org.forgerock.script.javascript.RhinoScriptEngineFactory;
@@ -27,12 +37,6 @@ import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.json.JsonValue.*;
 
 /**
  * Test ScriptedPatchValueTransformerFactory class.

--- a/openidm-security-jetty/pom.xml
+++ b/openidm-security-jetty/pom.xml
@@ -12,7 +12,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2011-2015 ForgeRock AS.
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -59,30 +59,10 @@
             <artifactId>osgi.cmpn</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
          <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-security/pom.xml
+++ b/openidm-security/pom.xml
@@ -13,7 +13,7 @@
  ~ information: "Portions copyright [year] [name of copyright owner]".
  ~
  ~ Copyright 2013-2016 ForgeRock AS.
- ~ Portions Copyright 2017-2018 Wren Security.
+ ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -96,13 +96,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -146,21 +139,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-security/src/main/java/org/forgerock/openidm/security/SecurityManager.java
+++ b/openidm-security/src/main/java/org/forgerock/openidm/security/SecurityManager.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.security;
@@ -20,14 +21,6 @@ import static org.forgerock.json.resource.Router.uriTemplate;
 
 import java.security.Security;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
@@ -54,8 +47,14 @@ import org.forgerock.openidm.security.impl.KeystoreResourceProvider;
 import org.forgerock.openidm.security.impl.PrivateKeyResourceProvider;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,13 +62,16 @@ import org.slf4j.LoggerFactory;
  * A Security Manager Service which handles operations on the java security
  * keystore and truststore files.
  */
-@Component(name = SecurityManager.PID, policy = ConfigurationPolicy.IGNORE, metatype = true, 
-        description = "OpenIDM Security Management Service", immediate = true)
-@Service
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "Security Management Service"),
-    @Property(name = ServerConstants.ROUTER_PREFIX, value = "/security/*") })
+@Component(
+        name = SecurityManager.PID,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+//        description = "OpenIDM Security Management Service",
+        immediate = true,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=/security/*"
+        })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Security Management Service")
 public class SecurityManager implements RequestHandler {
 
     static final String PID = "org.forgerock.openidm.security";
@@ -78,24 +80,24 @@ public class SecurityManager implements RequestHandler {
      * Setup logging for the {@link SecurityManager}.
      */
     private final static Logger logger = LoggerFactory.getLogger(SecurityManager.class);
-    
+
     @Reference
     protected RepositoryService repoService;
 
     @Reference
     private CryptoService cryptoService;
 
-    @Reference(target="(service.pid=org.forgerock.openidm.keystore)")
+    @Reference(target = "(component.name=org.forgerock.openidm.keystore)")
     private KeyStoreService keyStore;
 
-    @Reference(target="(service.pid=org.forgerock.openidm.truststore)")
+    @Reference(target = "(component.name=org.forgerock.openidm.truststore)")
     private KeyStoreService trustStore;
 
     @Reference
     private KeyStoreManagementService keyStoreManager;
 
     private final Router router = new Router();
-        
+
     public SecurityManager() {
         Security.addProvider(new BouncyCastleProvider());
     }

--- a/openidm-selfservice/pom.xml
+++ b/openidm-selfservice/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2012-2016 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -109,13 +109,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.forgerock.commons</groupId>
@@ -150,21 +143,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/KbaConfiguration.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/KbaConfiguration.java
@@ -12,32 +12,32 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.selfservice.impl;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * A KBA Configuration holder service.
  */
-@Component(name = KbaConfiguration.PID, immediate=true, policy = ConfigurationPolicy.REQUIRE)
-@Service({ KbaConfiguration.class })
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "KBA Configuration"),
-})
+@Component(
+        name = KbaConfiguration.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        service = KbaConfiguration.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("KBA Configuration")
 public class KbaConfiguration {
 
     static final String PID = "org.forgerock.openidm.selfservice.kba";

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/KbaService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/KbaService.java
@@ -12,35 +12,40 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.selfservice.impl;
 
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.resource.AbstractRequestHandler;
 import org.forgerock.json.resource.ReadRequest;
+import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
+import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * This service provides a path on the router for reading the KBA configuration.
  */
-@Component(name = KbaService.PID, immediate = true, policy = ConfigurationPolicy.IGNORE)
-@Service
-@Properties({
-        @Property(name = "service.description", value = "OpenIDM SelfService KBA Service"),
-        @Property(name = "service.vendor", value = "ForgeRock AS"),
-        @Property(name = "openidm.router.prefix", value = KbaService.ROUTER_PATH)
-})
+@Component(
+        name = KbaService.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=" + KbaService.ROUTER_PATH
+        },
+        service = RequestHandler.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM SelfService KBA Service")
 public class KbaService extends AbstractRequestHandler {
 
     static final String PID = "org.forgerock.openidm.selfservice.kbaservice";

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/PropertyMappingService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/PropertyMappingService.java
@@ -12,41 +12,41 @@
  * own identifying information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.selfservice.impl;
 
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.sync.PropertyMapping;
 import org.forgerock.openidm.sync.SynchronizationException;
 import org.forgerock.services.context.Context;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * JsonValue property mapping service. Currently bound only to mapping of IdP common schema to managed user.
  */
-@Component(name = PropertyMappingService.PID, immediate=true, policy = ConfigurationPolicy.REQUIRE)
-@Service({ PropertyMappingService.class })
-@Properties({
-    @Property(name = Constants.SERVICE_VENDOR, value = ServerConstants.SERVER_VENDOR_NAME),
-    @Property(name = Constants.SERVICE_DESCRIPTION, value = "Property Mapping Service"),
-})
+@Component(
+        name = PropertyMappingService.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        service = PropertyMappingService.class)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("Property Mapping Service")
 public class PropertyMappingService {
 
     static final String PID = "org.forgerock.openidm.selfservice.propertymap";

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
@@ -31,15 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.guava.common.base.Optional;
 import org.forgerock.guava.common.collect.FluentIterable;
 import org.forgerock.http.Client;
@@ -78,6 +69,15 @@ import org.forgerock.util.Options;
 import org.forgerock.util.encode.Base64;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,11 +85,13 @@ import org.slf4j.LoggerFactory;
  * This service supports self-registration, password reset, and forgotten username
  * per the Commons Self-Service stage configuration.
  */
-@Component(name = SelfService.PID, immediate = true, configurationFactory = true, policy = ConfigurationPolicy.REQUIRE)
-@Properties({
-    @Property(name = "service.description", value = "OpenIDM SelfService Service"),
-    @Property(name = "service.vendor", value = "ForgeRock AS"),
-})
+@Component(
+        name = SelfService.PID,
+        immediate = true,
+//        configurationFactory = true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE)
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM SelfService Service")
 public class SelfService implements IdentityProviderListener {
     static final String PID = "org.forgerock.openidm.selfservice";
 
@@ -134,7 +136,7 @@ public class SelfService implements IdentityProviderListener {
     @Reference
     private SharedKeyService sharedKeyService;
 
-    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL_UNARY)
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
     private volatile IdentityProviderService identityProviderService;
 
     @Reference(policy = ReferencePolicy.STATIC)

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/SelfService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2020 Wren Security.
  */
 
 package org.forgerock.openidm.selfservice.impl;
@@ -146,6 +146,10 @@ public class SelfService implements IdentityProviderListener {
     private ServiceRegistration<RequestHandler> serviceRegistration = null;
     private ComponentContext context;
     private ProgressStageProvider progressStageProvider;
+
+    void bindIdentityProviderService(IdentityProviderService identityProviderService) {
+        this.identityProviderService = identityProviderService;
+    }
 
     /**
      * Get the alias of the key self-service uses for pre-shared key encryption.

--- a/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/UserUpdateService.java
+++ b/openidm-selfservice/src/main/java/org/forgerock/openidm/selfservice/impl/UserUpdateService.java
@@ -12,20 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.selfservice.impl;
 
 import static org.forgerock.json.resource.ResourcePath.resourcePath;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
@@ -42,21 +34,32 @@ import org.forgerock.json.resource.ReadRequest;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.UpdateRequest;
+import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.router.IDMConnectionFactory;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.propertytypes.ServiceDescription;
+import org.osgi.service.component.propertytypes.ServiceVendor;
 
 /**
  * This service supports self-service updates of user details; namely, KBA answers.
  */
-@Component(name = UserUpdateService.PID, immediate = true, policy = ConfigurationPolicy.IGNORE)
-@Service
-@Properties({
-        @Property(name = "service.description", value = "OpenIDM SelfService User-Update"),
-        @Property(name = "service.vendor", value = "ForgeRock AS"),
-        @Property(name = "openidm.router.prefix", value = UserUpdateService.ROUTER_PATH)
-})
+@Component(
+        name = UserUpdateService.PID,
+        immediate = true,
+        configurationPolicy = ConfigurationPolicy.IGNORE,
+        property = {
+                ServerConstants.ROUTER_PREFIX + "=" + UserUpdateService.ROUTER_PATH
+        })
+@ServiceVendor(ServerConstants.SERVER_VENDOR_NAME)
+@ServiceDescription("OpenIDM SelfService User-Update")
 public class UserUpdateService implements CollectionResourceProvider {
     static final String PID = "org.forgerock.openidm.selfservice.userupdate";
 

--- a/openidm-servlet-registrator/pom.xml
+++ b/openidm-servlet-registrator/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright 2011-2015 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -84,13 +84,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -134,20 +127,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-servlet-registrator/src/main/java/org/forgerock/openidm/servletregistration/impl/ServletFilterConfiguration.java
+++ b/openidm-servlet-registrator/src/main/java/org/forgerock/openidm/servletregistration/impl/ServletFilterConfiguration.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock Inc.
+ * Portions Copyright 2020 Wren Security
  */
 
 package org.forgerock.openidm.servletregistration.impl;
@@ -21,19 +22,18 @@ import static org.forgerock.openidm.servletregistration.ServletRegistration.SERV
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.servletregistration.RegisteredFilter;
 import org.forgerock.openidm.servletregistration.ServletRegistration;
-
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,9 +45,8 @@ import org.slf4j.LoggerFactory;
 @Component(
         name = "org.forgerock.openidm.servletfilter",
         immediate = true,
-        policy = ConfigurationPolicy.REQUIRE,
-        configurationFactory=true
-)
+        // configurationFactory=true,
+        configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class ServletFilterConfiguration {
     private final static Logger logger = LoggerFactory.getLogger(ServletFilterConfiguration.class);
 
@@ -59,9 +58,9 @@ public class ServletFilterConfiguration {
 
     @Reference(
             name = "ref_ServletFilterRegistration",
-            referenceInterface = ServletRegistration.class,
+            service = ServletRegistration.class,
             policy = ReferencePolicy.DYNAMIC,
-            cardinality = ReferenceCardinality.MANDATORY_UNARY
+            cardinality = ReferenceCardinality.MANDATORY
     )
     private volatile ServletRegistration servletFilterRegistration;
 

--- a/openidm-servlet/pom.xml
+++ b/openidm-servlet/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright 2011-2015 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -91,12 +91,6 @@
       <artifactId>org.apache.felix.framework</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>org.apache.felix.scr.annotations</artifactId>
-        <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -107,20 +101,6 @@
     </resources>
 
     <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-scr-plugin</artifactId>
-
-        <executions>
-          <execution>
-            <id>generate-scr-scrdescriptor</id>
-            <goals>
-              <goal>scr</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-servlet/src/main/java/org/forgerock/openidm/ui/internal/service/ResourceServlet.java
+++ b/openidm-servlet/src/main/java/org/forgerock/openidm/ui/internal/service/ResourceServlet.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  * Portions copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.ui.internal.service;
 
@@ -32,19 +33,19 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Modified;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openidm.config.enhanced.EnhancedConfig;
 import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.PropertyUtil;
 import org.ops4j.pax.web.service.WebContainer;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,10 +58,12 @@ import org.slf4j.LoggerFactory;
  * Changes and additions by
  * Portions copyright 2017 Wren Security
  */
-@Component(name = "org.forgerock.openidm.ui.context", 
+@Component(
+        name = "org.forgerock.openidm.ui.context",
         immediate = true,
-        policy = ConfigurationPolicy.REQUIRE)
+        configurationPolicy = ConfigurationPolicy.REQUIRE)
 public final class ResourceServlet extends HttpServlet {
+
     private static final long serialVersionUID = 1;
 
     final static Logger logger = LoggerFactory.getLogger(ResourceServlet.class);
@@ -91,14 +94,14 @@ public final class ResourceServlet extends HttpServlet {
         logger.info("Activating resource servlet with configuration {}", context.getProperties());
         init(context);
     }
-    
+
     @Modified
     protected void modified(ComponentContext context) throws ServletException, NamespaceException {
         logger.info("Modifying resource servlet with configuration {}", context.getProperties());
         clear();
         init(context);
     }
-    
+
     @Deactivate
     protected void deactivate(ComponentContext context) {
         logger.info("Deactivating resource servlet with configuration {}", context.getProperties());
@@ -158,14 +161,14 @@ public final class ResourceServlet extends HttpServlet {
 
     /**
      * Initializes the servlet and registers it with the WebContainer.
-     * 
+     *
      * @param context the ComponentContext containing the configuration
      * @throws ServletException
      * @throws NamespaceException
      */
     private void init(ComponentContext context) throws ServletException, NamespaceException {
         JsonValue config = enhancedConfig.getConfigurationAsJson(context);
-        
+
         if (!config.get(CONFIG_ENABLED).isNull() && Boolean.FALSE.equals(config.get(CONFIG_ENABLED).asBoolean())) {
             logger.info("UI is disabled - not registering UI servlet");
             return;
@@ -190,7 +193,7 @@ public final class ResourceServlet extends HttpServlet {
         webContainer.registerServlet(contextRoot, this,  props, webContainer.getDefaultSharedHttpContext());
         logger.debug("Registered UI servlet at {}", contextRoot);
     }
-    
+
     /**
      * Clears the servlet, unregistering it with the WebContainer and removing the bundle listener.
      */
@@ -200,7 +203,7 @@ public final class ResourceServlet extends HttpServlet {
             logger.debug("Unregistered UI servlet at {}", contextRoot);
         }
     }
-    
+
     private void handle(HttpServletRequest req, HttpServletResponse res, URL url, String resName)
             throws IOException {
         String contentType = getServletContext().getMimeType(resName);
@@ -244,7 +247,7 @@ public final class ResourceServlet extends HttpServlet {
 
         return lastModified;
     }
-    
+
     private String getMimeType(String fileName) {
         if (fileName.endsWith(".css")) {
             return "text/css";
@@ -255,7 +258,7 @@ public final class ResourceServlet extends HttpServlet {
         } else if (fileName.endsWith(".html")) {
             return "text/html";
         }
-        
+
         return null;
     }
 

--- a/openidm-shell/pom.xml
+++ b/openidm-shell/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -91,13 +91,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -120,21 +113,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-smartevent/pom.xml
+++ b/openidm-smartevent/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -37,8 +37,7 @@
 
     <name>Wren:IDM - SmartEvent Bundle</name>
     <description>
-        Provides a way to monitor and respond to both low-level and application-level events in
-        Wren:IDM.
+        Provides a way to monitor and respond to both low-level and application-level events in Wren:IDM.
     </description>
 
     <dependencies>
@@ -75,12 +74,6 @@
             <artifactId>json-resource</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -103,22 +96,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Private-Package>org.forgerock.openidm.smartevent</Private-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/openidm-smartevent/src/test/java/org/forgerock/openidm/smartevent/PublisherTest.java
+++ b/openidm-smartevent/src/test/java/org/forgerock/openidm/smartevent/PublisherTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.smartevent;
 
@@ -34,24 +35,24 @@ import org.testng.annotations.Test;
 
 /**
  * Testing of smart event publisher
- * 
+ *
  */
 public class PublisherTest {
 
     // Format for information purposes
     final static NumberFormat MILLISEC_FORMAT = new DecimalFormat("###,###,##0.###### ms");
-    
+
     // Smart event names for the tests
     final static Name EVENT_BASIC_TEST = Name.get("openidm/test/basic");
     final static Name EVENT_PERF_SMOKE_TEST = Name.get("openidm/test/performance/smoketest");
 
     MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-    
+
     // Smart event also exposes statistics via JMX
     ObjectName getStatisticsMBean() throws MalformedObjectNameException {
         return new ObjectName(StatisticsHandler.MBEAN_NAME);
     }
-    
+
     @Test(enabled = true)
     public void validateStartEndStatistics() throws Exception {
         Object dummyPayload = new JsonValue("{'test': 'some value'}");
@@ -62,17 +63,17 @@ public class PublisherTest {
         Thread.sleep(100); // Statistics is not necessarily updated in a synchronous fashion
         Object totals = mbs.getAttribute(getStatisticsMBean(), "Totals");
         assertThat(totals).isInstanceOf(Map.class);
-        Object statisticsEntry = ((Map)totals).get(EVENT_BASIC_TEST.asString());
+        Object statisticsEntry = ((Map<?, ?>) totals).get(EVENT_BASIC_TEST.asString());
         assertThat(statisticsEntry).isNotNull()
                 .overridingErrorMessage("Expected a statistic entry for " + EVENT_BASIC_TEST + ", but is null.");
     }
-    
+
     /**
-     * Do a number of start/end measurements after an initial warm up, 
+     * Do a number of start/end measurements after an initial warm up,
      * single threaded
-     * Because of varying test environments the 
+     * Because of varying test environments the
      * failure condition for this basic performance smoke test
-     * is set at a lax level. 
+     * is set at a lax level.
      * Real performance (printed on standard out) should be much higher
     */
     @Test(enabled=true)
@@ -81,7 +82,7 @@ public class PublisherTest {
         int warmup = 100000;
         int iterations = 100000;
         int maxTimeToAllow = 10000; // ms time to allow for this test not to fail
-        
+
         Object dummyPayload = new JsonValue("{'test': 'value'}");
         Object dummyContext1 = "reconID: xyz123";
 
@@ -90,7 +91,7 @@ public class PublisherTest {
             measure.end();
         }
         Thread.sleep(200);
-        
+
         long start = System.currentTimeMillis();
         for (int i = 0; i < iterations; i++) {
             EventEntry measure = Publisher.start(EVENT_PERF_SMOKE_TEST, dummyPayload, dummyContext1);
@@ -102,10 +103,10 @@ public class PublisherTest {
                 + "took " + diff + " milliseconds. "
                 + "Each start/end event took approx: " + MILLISEC_FORMAT.format(diff/(double)iterations)
                 + ". This smoke test allows max " + maxTimeToAllow + " ms ");
-        
+
         assertThat(diff).isLessThan(maxTimeToAllow)
                 .overridingErrorMessage("Performance warning: " + iterations + " did not complete in the expected max "
                         + maxTimeToAllow + " ms");
     }
-    
+
 }

--- a/openidm-system/pom.xml
+++ b/openidm-system/pom.xml
@@ -29,8 +29,7 @@
 
     <name>Wren:IDM - System Bundle</name>
     <description>
-        Provides the logic necessary to load startup properties and bootstrap the core Wren:IDM
-        system.
+        Provides the logic necessary to load startup properties and bootstrap the core Wren:IDM system.
     </description>
 
     <dependencies>
@@ -156,6 +155,7 @@
                     <instructions>
                         <Bundle-Activator>org.forgerock.openidm.core.internal.Activator</Bundle-Activator>
                         <Bundle-Category>utility</Bundle-Category>
+                        <Bundle-Description>${project.description}</Bundle-Description>
                     </instructions>
                 </configuration>
             </plugin>

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/internal/Activator.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/internal/Activator.java
@@ -37,6 +37,7 @@ public class Activator implements BundleActivator {
 
     private ServiceTracker<Map<String, Object>, Map<String, Object>> serviceTracker = null;
 
+    @Override
     public void start(final BundleContext context) throws Exception {
         String customFilter = context.getProperty("org.forgerock.openidm.core.map.filter");
         Filter filter = null;
@@ -45,6 +46,11 @@ public class Activator implements BundleActivator {
                     context.createFilter("(&(" + Constants.OBJECTCLASS + "=java.util.Map)"
                             + customFilter + ")");
         } else {
+            // XXX Not sure why we need this construct and why config.properties is not
+            // enough. The only difference is that this file is not undergoing Felix's own
+            // property substitution. Also note that boot file is being loaded by launcher
+            // library as well with the exception that it is actually not loading it because
+            // launcher.json contains it's own values. [PH]
             filter =
                     context.createFilter("(&(" + Constants.OBJECTCLASS + "=java.util.Map)("
                             + Constants.SERVICE_PID
@@ -58,6 +64,7 @@ public class Activator implements BundleActivator {
                 new FrameworkPropertyAccessor(context, null)));
     }
 
+    @Override
     public void stop(BundleContext context) throws Exception {
         if (null != serviceTracker) {
             serviceTracker.close();

--- a/openidm-util/pom.xml
+++ b/openidm-util/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2015 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -129,12 +129,6 @@
 
         <!-- Provided Dependencies -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.forgerock.openidm</groupId>
             <artifactId>openidm-smartevent</artifactId>
             <version>${project.version}</version>
@@ -212,24 +206,17 @@
 
             <plugin>
                 <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
 
                 <configuration>
+                    <!--
+                        XXX Investigate this strange delegation to router bundle. This mixes BundleContexts 
+                        and class-loaders. If the reason behind this is some load order voodoo, then different
+                        start levels might be a better solution. [PH]
+                        XXX Another issue might be dependency loop this introduces (it is harder to deploy bundles
+                        sequentially for testing purposes) - util > router > enhanced-config > crypto > util. [PH] 
+                    -->
                     <instructions>
                         <Bundle-Activator>org.forgerock.openidm.router.Activator</Bundle-Activator>
                         <Bundle-Category>utility</Bundle-Category>

--- a/openidm-util/src/main/java/org/forgerock/openidm/external/ExternalException.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/external/ExternalException.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020 Wren Security
  */
 package org.forgerock.openidm.external;
 
@@ -21,6 +22,8 @@ import org.forgerock.json.resource.ResourceException;
  * A ResourceException that wraps a ResourceException generated externally to IDM, such as an external REST call.
  */
 public class ExternalException extends ResourceException {
+
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructs a new exception with the specified exception as the external cause.

--- a/openidm-util/src/main/java/org/forgerock/openidm/osgi/ComponentContextUtil.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/osgi/ComponentContextUtil.java
@@ -15,11 +15,11 @@
  */
 package org.forgerock.openidm.osgi;
 
-import org.osgi.service.component.ComponentContext;
-
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.Hashtable;
+
+import org.osgi.service.component.ComponentContext;
 
 /**
  * Utilities for augmenting ComponentContext behavior.

--- a/openidm-util/src/main/java/org/forgerock/openidm/osgi/OsgiName.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/osgi/OsgiName.java
@@ -38,7 +38,6 @@ import javax.naming.NamingException;
  * component 0: osgi:framework, osgi:service, openidm:services, osgi:servicelist
  * component 1: interface component 2: filter
  */
-@SuppressWarnings("serial")
 public class OsgiName extends CompositeName {
 
     private static final long serialVersionUID = 3567653491060394677L;

--- a/openidm-util/src/main/java/org/forgerock/openidm/osgi/ServiceTrackerNotifier.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/osgi/ServiceTrackerNotifier.java
@@ -61,17 +61,19 @@ public class ServiceTrackerNotifier<S, T> extends ServiceTracker<S, T> {
         this.context = context;
     }
 
+    @Override
     public T addingService(ServiceReference<S> reference) {
         T service =  super.addingService(reference);
         if (service == null) {
             logger.warn("Framework issue, service in service tracker is null for {}",
-                    reference.getProperty(Constants.SERVICE_PID));
+                    ServiceUtil.getServicePid(reference.getProperties()));
         }
         if (listener != null) {
             listener.addedService(reference, service);
         }
         return service;
     }
+    @Override
     public void removedService(ServiceReference<S> reference, T service) {
         if (listener != null) {
             listener.removedService(reference, service);
@@ -79,10 +81,11 @@ public class ServiceTrackerNotifier<S, T> extends ServiceTracker<S, T> {
         super.removedService(reference, service);
     }
 
+    @Override
     public void modifiedService(ServiceReference<S> reference, T service) {
         if (service == null) {
             logger.warn("Framework issue, service in service tracker modified is null for {}",
-                    reference.getProperty(Constants.SERVICE_PID));
+                    ServiceUtil.getServicePid(reference.getProperties()));
         }
         if (listener != null) {
             listener.modifiedService(reference, service);

--- a/openidm-util/src/main/java/org/forgerock/openidm/osgi/ServiceUtil.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/osgi/ServiceUtil.java
@@ -20,6 +20,7 @@ package org.forgerock.openidm.osgi;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Dictionary;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -27,6 +28,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentConstants;
 
 /**
  * Service helper utility, * Based on apache aries
@@ -35,6 +37,12 @@ import org.osgi.framework.ServiceReference;
 public final class ServiceUtil {
 
     private ServiceUtil() {
+    }
+
+    public static String getServicePid(Dictionary<String, ?> props) {
+        // XXX This can be array or collection [PH]
+        String pid = (String) props.get(Constants.SERVICE_PID);
+        return pid != null ? pid : (String) props.get(ComponentConstants.COMPONENT_NAME);
     }
 
     public static Object getService(BundleContext ctx, OsgiName lookupName, String id,
@@ -89,6 +97,7 @@ public final class ServiceUtil {
             if (refs != null) {
                 // change the service order
                 Arrays.sort(refs, new Comparator<ServiceReference<?>>() {
+                    @Override
                     public int compare(ServiceReference<?> o1, ServiceReference<?> o2) {
                         return o2.compareTo(o1);
                     }

--- a/openidm-workflow-activiti/pom.xml
+++ b/openidm-workflow-activiti/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -234,13 +234,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -257,21 +250,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -3,7 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright 2011-2016 ForgeRock AS. All Rights Reserved
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -256,6 +256,21 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.promise</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.function</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.pushstream</artifactId>
         </dependency>
 
         <dependency>

--- a/openidm-zip/src/main/assembly/zip.xml
+++ b/openidm-zip/src/main/assembly/zip.xml
@@ -1186,8 +1186,7 @@
                 <exclude>org.apache.olingo:*</exclude>
                 <exclude>com.fasterxml:aalto-xml</exclude>
                 <exclude>org.forgerock.openidm.tools:custom-scripted-connector-bundler:*</exclude>
-                <!--exclude>org.apache.felix:org.apache.felix.scr.annotations</exclude>
-                <exclude>javax.persistence:persistence-api</exclude>
+                <!--exclude>javax.persistence:persistence-api</exclude>
                 <exclude>javax.transaction:jta</exclude>
                 <exclude>org.apache.felix:org.apache.felix.main</exclude>
                 <exclude>org.apache.felix:org.osgi.foundation</exclude>

--- a/openidm-zip/src/main/resources/conf/config.properties
+++ b/openidm-zip/src/main/resources/conf/config.properties
@@ -92,8 +92,8 @@ org.ops4j.pax.web.config.file=&{launcher.project.location}/conf/jetty.xml
 org.osgi.service.http.enabled=true
 org.osgi.service.http.secure.enabled=true
 
-# Disable the file configuration uncomment these options and enable the bootstrap in the system.properties.
-#felix.fileinstall.disableConfigSave=false
+# Disable file configuration update
+felix.fileinstall.enableConfigSave=false
 
 # Add the windows server 2012 osname alias until https://issues.apache.org/jira/browse/FELIX-5184 is fixed.
 felix.native.osname.alias.windowsserver2012=windows server 2012,win32

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2011-2016 ForgeRock AS.
-  ~ Portions Copyright 2017-2018 Wren Security.
+  ~ Portions Copyright 2017-2020 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -109,10 +109,11 @@
 
     <properties>
 
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.4.5</pgpWhitelistArtifact>
+        <pgpVerifyPluginVersion>1.10.1-wren</pgpVerifyPluginVersion>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.0</pgpWhitelistArtifact>
 
         <!-- Version management -->
-        <commons.commons-bom.version>22.0.0</commons.commons-bom.version>
+        <commons.commons-bom.version>22.0.1-SNAPSHOT</commons.commons-bom.version>
 
         <!-- Commons versions -->
         <commons.forgerock-script.version>4.3.0</commons.forgerock-script.version>
@@ -134,30 +135,31 @@
         <rhino.version>1.7R4_1</rhino.version>
         <groovy.version>2.4.7</groovy.version>
 
-        <!-- OSGi/Felix versions -->
-        <!-- Felix 5.4 Framework implements OSGi R6 specification -->
-        <osgi.core.version>6.0.0</osgi.core.version>
-        <osgi.compendium.version>6.0.0</osgi.compendium.version>
-        <osgi.enterprise.version>6.0.0</osgi.enterprise.version>
+        <!-- OSGi / Felix versions -->
+        <osgi.core.version>7.0.0</osgi.core.version>
+        <osgi.compendium.version>7.0.0</osgi.compendium.version>
+        <osgi.enterprise.version>7.0.0</osgi.enterprise.version>
+        <osgi.promise.version>1.1.1</osgi.promise.version>
+        <osgi.function.version>1.1.0</osgi.function.version>
+        <osgi.pushstream.version>1.0.1</osgi.pushstream.version>
 
-        <felix.framework.version>5.4.0</felix.framework.version>
-        <felix.configadmin.version>1.8.8</felix.configadmin.version>
-        <felix.eventadmin.version>1.4.6</felix.eventadmin.version>
-        <felix.gogo.shell.version>0.12.0</felix.gogo.shell.version>
-        <felix.inventory.version>1.0.4</felix.inventory.version>
+        <felix.framework.version>6.0.3</felix.framework.version>
+        <felix.configadmin.version>1.9.18</felix.configadmin.version>
+        <felix.eventadmin.version>1.5.0</felix.eventadmin.version>
+        <felix.gogo.shell.version>1.1.4</felix.gogo.shell.version>
+        <felix.inventory.version>1.0.6</felix.inventory.version>
         <felix.metatype.version>1.1.2</felix.metatype.version>
-        <felix.fileinstall.version>3.5.4</felix.fileinstall.version>
-        <felix.log.version>1.0.1</felix.log.version>
-        <felix.scr.version>2.0.6</felix.scr.version>
-        <felix.scr.annotations.version>1.10.0</felix.scr.annotations.version>
+        <felix.fileinstall.version>3.6.4</felix.fileinstall.version>
+        <felix.log.version>1.2.2</felix.log.version>
+        <felix.scr.version>2.1.20</felix.scr.version>
         <felix.shell.version>1.4.3</felix.shell.version>
         <felix.shell.tui.version>1.4.1</felix.shell.tui.version>
-        <felix.webconsole.version>4.2.16</felix.webconsole.version>
-        <felix.webconsole.ds.version>2.0.2</felix.webconsole.ds.version>
-        <felix.webconsole.event.version>1.1.4</felix.webconsole.event.version>
-        <felix.webconsole.memoryusage.version>1.0.6</felix.webconsole.memoryusage.version>
-        <felix.webconsole.obr.version>1.0.2</felix.webconsole.obr.version>
-        <felix.webconsole.packageadmin.version>1.0.2</felix.webconsole.packageadmin.version>
+        <felix.webconsole.version>4.5.4</felix.webconsole.version>
+        <felix.webconsole.ds.version>2.1.0</felix.webconsole.ds.version>
+        <felix.webconsole.event.version>1.1.8</felix.webconsole.event.version>
+        <felix.webconsole.memoryusage.version>1.0.10</felix.webconsole.memoryusage.version>
+        <felix.webconsole.obr.version>1.0.4</felix.webconsole.obr.version>
+        <felix.webconsole.packageadmin.version>1.0.4</felix.webconsole.packageadmin.version>
 
         <!-- Wren:ICF Framework and Connector versions -->
         <openicf.framework.version>1.5.2.1</openicf.framework.version>
@@ -187,7 +189,7 @@
         <!-- Apache Commons versions -->
         <apache.commons-codec.version>1.10</apache.commons-codec.version>
         <apache.commons-io.version>2.5</apache.commons-io.version>
-        <apache.commons-fileupload.version>1.3.2</apache.commons-fileupload.version>
+        <apache.commons-fileupload.version>1.4</apache.commons-fileupload.version>
     </properties>
 
     <modules>
@@ -470,6 +472,24 @@
             </dependency>
 
             <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.promise</artifactId>
+                <version>${osgi.promise.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.function</artifactId>
+                <version>${osgi.function.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.pushstream</artifactId>
+                <version>${osgi.pushstream.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.framework</artifactId>
                 <version>${felix.framework.version}</version>
@@ -616,15 +636,6 @@
                 <version>${felix.scr.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.scr.annotations</artifactId>
-                <version>${felix.scr.annotations.version}</version>
-                <!--<version>1.9.2</version>-->
-                <!-- The anotation @Retention(RetentionPolicy.SOURCE) changed to @Retention(RetentionPolicy.CLASS) -->
-                <scope>provided</scope>
-            </dependency>
-
             <!-- Quartz based scheduler OSGi bundle.
                  This version wraps the original jar which is not a bundle
             -->
@@ -746,15 +757,8 @@
 
                 <plugin>
                     <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-scr-plugin</artifactId>
-                    <version>1.22.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <!-- version >= 2.5.4 introduces timestamp bug on UI files - see OPENIDM-5264 -->
-                    <version>2.5.3</version>
+                    <version>5.1.1</version>
                     <extensions>true</extensions>
 
                     <configuration>


### PR DESCRIPTION
## Dependency changes

* ✔ JRE version was upgraded to 1.8.
* ✔ Felix framework upgraded to 6.0.x.
* ❌ Left a lot of dependencies at their old versions (e.g. Gogo Shell). We should continue with the upgrade after this gets merged.

## Implementation changes (OSGi specific)

* ✔ All Felix SCR Annotations were replaced with standard OSGi DS annotations.
* ✔ Previous implementation was using `factory=true` with `suppressMetatypeWarning` properties to generate empty OCD. Such construct is not possible with DS and I am not sure what purpose it had. Those properties were removed.
* ✔ Previous Felix SCR Maven plugin was automatically generating `service.pid` based on component name. This property is used on a lot of places in service lookup / filters. This approach is not possible with DS (see [FELIX-5304](https://issues.apache.org/jira/browse/FELIX-5304)). Service PID properties were removed where possible, however additional cleanup is still needed.

## Bundle changes (metadata)

* ❌ Link to Creative Commons license disappeared from `Bundle-License` manifest attribute. This was not an intentional change, but it probably doesn't matter as CC-BY-NC was for docbook documentation.
* ✔ Newer build produces more exhaustive `Import-Packages` configuration. Seems to be in the direction of best-practices and should be ok.

## Known (unrelated) issues

* Current `master` branch is broken due to wrensecurity/wrensec-commons#22 (not caused by the upgrade).
 