### PR TITLE
Add support for Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [8, 11]
+    name: "Java ${{ matrix.java }} build"
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/custom-scripted-connector-bundler/pom.xml
+++ b/custom-scripted-connector-bundler/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
             <scope>provided</scope>
         </dependency>
 
@@ -148,7 +149,8 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>2.2.2</version>
+                        <version>2.5.13</version>
+                        <type>pom</type>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/openidm-launcher/pom.xml
+++ b/openidm-launcher/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>openidm-launcher</artifactId>
-    
+
     <name>ForgeRock OSGi Launcher Main</name>
 
     <dependencies>
@@ -79,7 +79,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.5</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -126,17 +125,17 @@
                                 <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.configadmin</artifactId>
-                                    <version>1.6.0</version>
+                                    <version>${felix.configadmin.version}</version>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.log</artifactId>
-                                    <version>1.0.1</version>
+                                    <version>${felix.log.version}</version>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.felix</groupId>
                                     <artifactId>org.apache.felix.fileinstall</artifactId>
-                                    <version>3.2.6</version>
+                                    <version>${felix.fileinstall.version}</version>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}/osgi/bundle</outputDirectory>

--- a/openidm-provisioner-openicf/pom.xml
+++ b/openidm-provisioner-openicf/pom.xml
@@ -148,6 +148,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
 

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/datasource/jdbc/impl/HikariCPDataSourceConfig.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/datasource/jdbc/impl/HikariCPDataSourceConfig.java
@@ -22,7 +22,7 @@ import com.zaxxer.hikari.HikariConfig;
  */
 class HikariCPDataSourceConfig extends AbstractConnectionDataSourceConfig {
 
-    private HikariConfig connectionPool;
+    private HikariConfigEx connectionPool;
 
     public HikariConfig getConnectionPool() {
         return connectionPool;
@@ -32,4 +32,9 @@ class HikariCPDataSourceConfig extends AbstractConnectionDataSourceConfig {
     public <R, P> R accept(DataSourceConfigVisitor<R, P> visitor, P parameters) {
         return visitor.visit(this, parameters);
     }
+
+    // FIXME Workaround for gadget blocking in jackson-databind's SubTypeValidator
+    static class HikariConfigEx extends HikariConfig {
+    }
+
 }

--- a/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTestUtils.java
+++ b/openidm-system/src/test/java/org/forgerock/openidm/core/IdentityServerTestUtils.java
@@ -16,13 +16,13 @@
 
 package org.forgerock.openidm.core;
 
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
-import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_INSTALL_LOCATION;
+import static org.forgerock.openidm.core.ServerConstants.LAUNCHER_PROJECT_LOCATION;
 
 /**
  * A utility class for tests that depend on the state of
@@ -73,19 +73,19 @@ public final class IdentityServerTestUtils {
      *   IDM install folder than the root of the test classpath.
      */
     public static void initInstanceForTest(Class<?> testClass) {
+
         final Path classpathRoot;
         final String classpathRootAbsolute;
-
         try {
-            classpathRoot = Paths.get(testClass.getClass().getResource("/").toURI());
+            classpathRoot = Paths.get(testClass.getResource("/").toURI());
         } catch (URISyntaxException ex) {
             throw new RuntimeException("Failed to parse classpath", ex);
         }
 
         classpathRootAbsolute = classpathRoot.toFile().getAbsolutePath();
-
         initInstanceForTest(classpathRootAbsolute, classpathRootAbsolute);
     }
+
 
     /**
      * Attempts to initialize the global {@code IdentityServer} instance to use the specified

--- a/openidm-workflow-activiti/pom.xml
+++ b/openidm-workflow-activiti/pom.xml
@@ -91,7 +91,7 @@
 
             <exclusions>
                 <exclusion>
-                    <artifactId>activation</artifactId>
+                    <artifactId>javax.activation-api</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>
 
@@ -117,6 +117,12 @@
             <groupId>org.activiti</groupId>
             <artifactId>activiti-osgi</artifactId>
             <version>5.23.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>javax.activation-api</artifactId>
+                    <groupId>javax.activation</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -488,6 +488,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
         </dependency>
 
         <dependency>
@@ -515,7 +516,6 @@
             <artifactId>pax-web-spi</artifactId>
             <version>${paxweb.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-finder</artifactId>
@@ -686,7 +686,7 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>
-            <version>3.1.4</version>
+            <version>4.2.1</version>
         </dependency>
 
         <dependency>
@@ -811,7 +811,7 @@
                         </goals>
 
                         <configuration>
-                            <tasks>
+                            <targets>
                                 <zip basedir="${basedir}/src/main/resources/samples/usecase/workflow" destfile="${project.build.directory}/bar-files/samples/usecase/workflow/certificationRoles.bar" includes="certificationRoles*" />
 
                                 <zip basedir="${basedir}/src/main/resources/samples/usecase/workflow" destfile="${project.build.directory}/bar-files/samples/usecase/workflow/certificationEntitlements.bar" includes="certificationEntitlements*" />
@@ -823,7 +823,7 @@
                                 <zip basedir="${basedir}/src/main/resources/samples/workflow/workflow" destfile="${project.build.directory}/bar-files/samples/workflow/workflow/chess.bar" includes="chess*" />
 
                                 <zip basedir="${basedir}/src/main/resources/samples/workflow/workflow" destfile="${project.build.directory}/bar-files/samples/workflow/workflow/contractorOnboarding.bar" includes="contractor*" />
-                            </tasks>
+                            </targets>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.forgerock.openidm</groupId>
@@ -110,27 +110,27 @@
     <properties>
 
         <pgpVerifyPluginVersion>1.10.1</pgpVerifyPluginVersion>
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.2-SNAPSHOT</pgpWhitelistArtifact>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.3-SNAPSHOT</pgpWhitelistArtifact>
 
         <!-- Version management -->
-        <commons.commons-bom.version>22.0.1-SNAPSHOT</commons.commons-bom.version>
+        <commons.commons-bom.version>22.1.0-SNAPSHOT</commons.commons-bom.version>
 
         <!-- Commons versions -->
-        <commons.forgerock-script.version>4.3.0</commons.forgerock-script.version>
+        <commons.forgerock-script.version>4.4.0-SNAPSHOT</commons.forgerock-script.version>
         <commons.forgerock-i18n.version>1.4.2</commons.forgerock-i18n.version>
 
         <!-- Third party dependency versions -->
         <javascript.maven.plugin.version>2.0.0-alpha-1</javascript.maven.plugin.version>
-        <joda-time.version>2.10.1</joda-time.version>
+        <joda-time.version>2.10.9</joda-time.version>
         <h2.version>1.4.200</h2.version>
-        <paxweb.version>4.2.7</paxweb.version>
+        <paxweb.version>4.3.6</paxweb.version>
         <javax.inject.version>1_3</javax.inject.version>
-        <xbean.version>4.5</xbean.version>
-        <asm.version>5.0.4</asm.version>
+        <xbean.version>4.18</xbean.version>
+        <asm.version>9.0</asm.version>
         <!-- quartz 2.x is not compatible yet -->
         <quartz.version>1.8.6_1</quartz.version>
-        <rhino.version>1.7R4_1</rhino.version>
-        <groovy.version>2.4.7</groovy.version>
+        <rhino.version>1.7.13_1</rhino.version>
+        <groovy.version>2.5.13</groovy.version>
 
         <!-- OSGi / Felix versions -->
         <osgi.core.version>7.0.0</osgi.core.version>
@@ -141,17 +141,17 @@
         <osgi.pushstream.version>1.0.1</osgi.pushstream.version>
 
         <felix.framework.version>6.0.3</felix.framework.version>
-        <felix.configadmin.version>1.9.18</felix.configadmin.version>
-        <felix.eventadmin.version>1.5.0</felix.eventadmin.version>
+        <felix.configadmin.version>1.9.20</felix.configadmin.version>
+        <felix.eventadmin.version>1.6.2</felix.eventadmin.version>
         <felix.gogo.shell.version>1.1.4</felix.gogo.shell.version>
         <felix.inventory.version>1.0.6</felix.inventory.version>
-        <felix.metatype.version>1.1.2</felix.metatype.version>
-        <felix.fileinstall.version>3.6.4</felix.fileinstall.version>
-        <felix.log.version>1.2.2</felix.log.version>
-        <felix.scr.version>2.1.20</felix.scr.version>
+        <felix.metatype.version>1.2.4</felix.metatype.version>
+        <felix.fileinstall.version>3.6.8</felix.fileinstall.version>
+        <felix.log.version>1.2.4</felix.log.version>
+        <felix.scr.version>2.1.24</felix.scr.version>
         <felix.shell.version>1.4.3</felix.shell.version>
         <felix.shell.tui.version>1.4.1</felix.shell.tui.version>
-        <felix.webconsole.version>4.5.4</felix.webconsole.version>
+        <felix.webconsole.version>4.6.0</felix.webconsole.version>
         <felix.webconsole.ds.version>2.1.0</felix.webconsole.ds.version>
         <felix.webconsole.event.version>1.1.8</felix.webconsole.event.version>
         <felix.webconsole.memoryusage.version>1.0.10</felix.webconsole.memoryusage.version>
@@ -431,7 +431,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.0</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -644,6 +644,7 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
+                <type>pom</type>
                 <version>${groovy.version}</version>
             </dependency>
 


### PR DESCRIPTION
# Wren:IDM now builds and runs on Java 11

Changes: 
- Majority of the dependencies were upgraded to newer version 
- Updated startup script to allow Felix (and Groovy and Activiti framework) reflective access to Java internals. Otherwise Idm doesn't run at all (in case of Felix), or spews warnings (all the other offenders)
- Updated CI script to build with both Java 8 and 11


