### PR TITLE
Revert Groovy upgrade. (#97)

### DIFF
--- a/custom-scripted-connector-bundler/pom.xml
+++ b/custom-scripted-connector-bundler/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <type>pom</type>
             <scope>provided</scope>
         </dependency>
 
@@ -149,8 +148,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>2.5.13</version>
-                        <type>pom</type>
+                        <version>2.2.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/openidm-provisioner-openicf/pom.xml
+++ b/openidm-provisioner-openicf/pom.xml
@@ -148,7 +148,6 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <type>pom</type>
             <scope>test</scope>
         </dependency>
 

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -488,7 +488,6 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/openidm-zip/src/main/resources/startup.sh
+++ b/openidm-zip/src/main/resources/startup.sh
@@ -45,6 +45,7 @@ COMPATIBILITY_OPTS=""
 if [ $JAVA_VER -gt 18 ]; then
     COMPATIBILITY_OPTS="--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
         --add-opens=java.base/java.lang=ALL-UNNAMED
+        --add-opens=java.base/java.lang.invoke=ALL-UNNAMED # Hides warning caused by Groovy 2.4.7, remove this once Groovy is upgraded (#97)
         --add-opens=java.base/java.net=ALL-UNNAMED
         --add-opens=java.base/java.util=ALL-UNNAMED"
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <!-- quartz 2.x is not compatible yet -->
         <quartz.version>1.8.6_1</quartz.version>
         <rhino.version>1.7.13_1</rhino.version>
-        <groovy.version>2.5.13</groovy.version>
+        <groovy.version>2.4.7</groovy.version>
 
         <!-- OSGi / Felix versions -->
         <osgi.core.version>7.0.0</osgi.core.version>
@@ -644,7 +644,6 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <type>pom</type>
                 <version>${groovy.version}</version>
             </dependency>
 


### PR DESCRIPTION
I have reverted Groovy back to previous version as a quick workaround for #97.