### PR TITLE
Add .dockerignore (#91).

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore everything except wrenidm build
+**
+!openidm-zip/target/wrenidm-*.zip


### PR DESCRIPTION
I have added base `.dockerignore` to ignore everything except wrenidm build.