### PR TITLE
Fix unnecessary keystore overwrite when nothing changed.

### DIFF
--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreInitializer.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreInitializer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2020-2021 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
@@ -19,6 +20,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 
 import org.forgerock.openidm.keystore.KeyStoreDetails;
+import org.forgerock.openidm.keystore.KeyStoreService;
 
 /**
  * Interface for loading and initializing the keystore and truststore.
@@ -35,11 +37,11 @@ public interface KeyStoreInitializer {
 
     /**
      * Loads and initializes the truststore.
-     * @param keyStore the keystore to store the ssl cert to.
+     * @param keyStoreService the keystore service to store the ssl cert to.
      * @param keyStoreDetails the truststore {@link KeyStoreDetails truststore details}.
      * @return the loaded and initialized {@link KeyStore truststore}.
      * @throws GeneralSecurityException if unable to load or initialize the {@link KeyStore truststore}.
      */
-    KeyStore initializeTrustStore(final KeyStore keyStore, final KeyStoreDetails keyStoreDetails)
+    KeyStore initializeTrustStore(final KeyStoreService keyStoreService, final KeyStoreDetails keyStoreDetails)
             throws GeneralSecurityException;
 }

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/KeyStoreServiceImpl.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2021 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
@@ -80,7 +80,6 @@ public class KeyStoreServiceImpl extends AbstractKeyStoreService {
     public void activate(@SuppressWarnings("unused") ComponentContext context) throws GeneralSecurityException {
         logger.debug("Activating key store service");
         this.store = keyStoreInitializer.initializeKeyStore(getKeyStoreDetails());
-        store();
     }
 
     /**

--- a/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImpl.java
+++ b/openidm-keystore/src/main/java/org/forgerock/openidm/keystore/impl/TrustStoreServiceImpl.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2021 Wren Security
  */
 package org.forgerock.openidm.keystore.impl;
 
@@ -85,9 +85,7 @@ public class TrustStoreServiceImpl extends AbstractKeyStoreService {
     @Activate
     public void activate(@SuppressWarnings("unused") ComponentContext context) throws GeneralSecurityException {
         logger.debug("Activating trust store service");
-        this.store = keyStoreInitializer.initializeTrustStore(keyStore.getKeyStore(), keyStoreDetails);
-        store();
-        keyStore.store();
+        this.store = keyStoreInitializer.initializeTrustStore(keyStore, keyStoreDetails);
     }
 
     @Deactivate

--- a/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
+++ b/openidm-keystore/src/test/java/org/forgerock/openidm/keystore/impl/DefaultKeyStoreInitializerTest.java
@@ -13,7 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018-2020 Wren Security.
+ * Portions Copyright 2018-2021 Wren Security.
  */
 
 package org.forgerock.openidm.keystore.impl;
@@ -30,6 +30,8 @@ import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_PASSWORD;
 import static org.forgerock.openidm.core.IdentityServer.TRUSTSTORE_TYPE;
 import static org.forgerock.openidm.core.ServerConstants.JWTSESSION_SIGNING_KEY_ALIAS_PROPERTY;
 import static org.forgerock.openidm.core.ServerConstants.SELF_SERVICE_CERT_ALIAS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -43,6 +45,7 @@ import org.forgerock.openidm.core.IdentityServer;
 import org.forgerock.openidm.core.IdentityServerTestUtils;
 import org.forgerock.openidm.core.ServerConstants;
 import org.forgerock.openidm.keystore.KeyStoreDetails;
+import org.forgerock.openidm.keystore.KeyStoreService;
 import org.forgerock.security.keystore.KeyStoreType;
 import org.forgerock.util.Utils;
 import org.testng.annotations.BeforeClass;
@@ -90,8 +93,11 @@ public class DefaultKeyStoreInitializerTest {
         final KeyStoreDetails keyStoreDetails = createKeyStoreDetails();
         final KeyStore keyStore = defaultKeyStoreInitializer.initializeKeyStore(keyStoreDetails);
 
+        final KeyStoreService keyStoreService = mock(KeyStoreService.class);
+        when(keyStoreService.getKeyStore()).thenReturn(keyStore);
+
         // when
-        final KeyStore trustStore = defaultKeyStoreInitializer.initializeTrustStore(keyStore, keyStoreDetails);
+        final KeyStore trustStore = defaultKeyStoreInitializer.initializeTrustStore(keyStoreService, keyStoreDetails);
 
         // then
         final String alias = IdentityServer.getInstance().getProperty(


### PR DESCRIPTION
This PR removes unnecessary keystore file overwrite during IDM startup. Without this change keystore and truststore files need to be writable by the IDM even though nothing is being changed by the IDM.

```
Aug 27, 2021 12:35:03 PM org.forgerock.openidm.keystore.impl.AbstractKeyStoreService store
WARNING: Unable to store keystore
java.io.FileNotFoundException: /opt/wrenidm/security/keystore.jceks (Read-only file system)
        at java.base/java.io.FileOutputStream.open0(Native Method)
        at java.base/java.io.FileOutputStream.open(FileOutputStream.java:298)
        at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:237)
        at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:126)
        at org.forgerock.openidm.keystore.KeyStoreDetails.getOutputStream(KeyStoreDetails.java:94)
        at org.forgerock.openidm.keystore.impl.AbstractKeyStoreService.store(AbstractKeyStoreService.java:109)
        at org.forgerock.openidm.keystore.impl.KeyStoreServiceImpl.store(KeyStoreServiceImpl.java:48)
        at org.forgerock.openidm.keystore.impl.KeyStoreServiceImpl.activate(KeyStoreServiceImpl.java:83)
        at org.forgerock.openidm.keystore.factory.KeyStoreServiceFactory.getInstance(KeyStoreServiceFactory.java:45)
...
```

Main motivation was to allow read-only secret mount in k8s deployment.