### PR TITLE
Fix build of Docker image on arm64 (#136)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM maven:3.8.6-eclipse-temurin-17 AS project-build
-
-RUN apt-get update
+FROM maven:3.8.6-eclipse-temurin-17-alpine AS project-build
 
 # Install management tools
-RUN apt-get install -y unzip
+RUN apk add unzip
 
-# Install headless Chrome dependencies
-RUN apt-get install -y ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 \
-    libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 \
-    libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxshmfence1 libxcomposite1 libxcursor1 \
-    libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 libxcb-dri3-0 lsb-release wget xdg-utils \
-    --no-install-recommends
-
+# Install and configure headless Chrome for Puppeteer
+RUN apk add chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # Use '--no-sandbox' option for Puppeteer's Chromium because of incompatibility with Docker
 ENV DISABLE_PUPPETEER_SANDBOX=true
 

--- a/openidm-ui/Gruntfile-common.js
+++ b/openidm-ui/Gruntfile-common.js
@@ -215,7 +215,8 @@ module.exports = function(grunt, options) {
                     args: [
                         process.env.DISABLE_PUPPETEER_SANDBOX ? "--no-sandbox" : "",
                         "--headless",
-                        "--allow-file-access-from-files"
+                        "--allow-file-access-from-files",
+                        "--disable-dev-shm-usage"
                     ]
                 }
             }

--- a/openidm-ui/pom.xml
+++ b/openidm-ui/pom.xml
@@ -63,7 +63,6 @@
                             <configuration>
                                 <nodeVersion>v14.17.0</nodeVersion>
                                 <npmVersion>6.14.13</npmVersion>
-                                <downloadRoot>https://nodejs.org/dist/</downloadRoot>
                                 <npmDownloadRoot>https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Docker stage `project-build` is now using Alpine linux with preinstalled Chromium browser for Puppeteer. So the browser is not installed through the Puppeteer anymore.