### PR TITLE
Use Wren:IDM in status messages.

### DIFF
--- a/openidm-config/src/main/java/org/forgerock/openidm/config/persistence/Activator.java
+++ b/openidm-config/src/main/java/org/forgerock/openidm/config/persistence/Activator.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2023 Wren Security
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -78,7 +79,7 @@ public class Activator implements BundleActivator {
         // Configure pax web properties
         PaxWeb.configurePaxWebProperties();
 
-        logger.info("OpenIDM is starting from {}", IdentityServer.getInstance().getServerRoot());
+        logger.info("Wren:IDM is starting from {}", IdentityServer.getInstance().getServerRoot());
     }
 
     public void stop(BundleContext context) {

--- a/openidm-customendpoint/src/main/java/org/forgerock/openidm/customendpoint/impl/EndpointsService.java
+++ b/openidm-customendpoint/src/main/java/org/forgerock/openidm/customendpoint/impl/EndpointsService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2023 Wren Security
  */
 package org.forgerock.openidm.customendpoint.impl;
 
@@ -84,14 +84,14 @@ public class EndpointsService extends AbstractScriptedService {
         setProperties(context);
         setProperty(ServerConstants.ROUTER_PREFIX, getRouterPrefixes(factoryPid, configuration));
         registerService(context.getBundleContext(), configuration);
-        logger.info("OpenIDM Endpoints Service \"{}\" component is activated.", factoryPid);
+        logger.info("Wren:IDM Endpoints Service \"{}\" component is activated.", factoryPid);
     }
 
     @Deactivate
     protected void deactivate(ComponentContext context) {
         unregisterService();
         this.context = null;
-        logger.info("OpenIDM Endpoints Service component is deactivated.");
+        logger.info("Wren:IDM Endpoints Service component is deactivated.");
     }
 
     private String[] getRouterPrefixes(String factoryPid, JsonValue configuration) {

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/impl/HealthService.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/impl/HealthService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2023 Wren Security
  */
 package org.forgerock.openidm.info.impl;
 
@@ -162,7 +162,7 @@ public class HealthService
     /**
      * The current state of OpenIDM
      */
-    private volatile StateDetail stateDetail = new StateDetail(AppState.STARTING, "OpenIDM starting");
+    private volatile StateDetail stateDetail = new StateDetail(AppState.STARTING, "Wren:IDM starting");
 
     /**
      * Bundles and bundle fragments required to be started or resolved respectively for the system to
@@ -398,7 +398,7 @@ public class HealthService
             scheduleCheckStartup(2000);
         }
 
-        logger.info("OpenIDM Health Service component is activated.");
+        logger.info("Wren:IDM Health Service component is activated.");
     }
 
     /**
@@ -451,7 +451,7 @@ public class HealthService
                                      // than starting if something fails
                 checkState();
                 if (!stateDetail.state.equals(AppState.ACTIVE_READY)) {
-                    logger.error("OpenIDM failure during startup, {}: {}", stateDetail.state,
+                    logger.error("Wren:IDM failure during startup, {}: {}", stateDetail.state,
                             stateDetail.shortDesc);
                 } else {
                     logger.debug("Startup check found ready state");
@@ -593,7 +593,7 @@ public class HealthService
             updatedShortDesc = "This node can not yet join the cluster";
         } else {
             updatedAppState = AppState.ACTIVE_READY;
-            updatedShortDesc = "OpenIDM ready";
+            updatedShortDesc = "Wren:IDM ready";
         }
         setState(updatedAppState, updatedShortDesc);
     }
@@ -641,9 +641,9 @@ public class HealthService
                 // IF we're changing to a ready state, report ready
                 if (!stateDetail.isState(AppState.ACTIVE_READY)
                         && updatedState.isState(AppState.ACTIVE_READY)) {
-                    logger.info("OpenIDM ready");
+                    logger.info("Wren:IDM ready");
                     // Show ready on the system console
-                    System.out.println("OpenIDM ready");
+                    System.out.println("Wren:IDM ready");
                 }
 
                 stateDetail = updatedState;
@@ -699,8 +699,8 @@ public class HealthService
         // that the system may be shutting down
         // Ideally replace with enhanced detection on regular shutdown initiated
         frameworkStarted = false;
-        setState(AppState.STOPPING, "OpenIDM stopping");
-        logger.info("OpenIDM Health Service component is deactivated.");
+        setState(AppState.STOPPING, "Wren:IDM stopping");
+        logger.info("Wren:IDM Health Service component is deactivated.");
     }
 
     /**

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/impl/InfoService.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/impl/InfoService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2023 Wren Security
  */
 package org.forgerock.openidm.info.impl;
 
@@ -105,14 +105,14 @@ public class InfoService extends AbstractScriptedService {
         setProperties(context);
         setProperty(ServerConstants.ROUTER_PREFIX, "/info/" + String.valueOf(factoryPid) + "*");
         registerService(context.getBundleContext(), configuration);
-        logger.info("OpenIDM Info Service \"{}\" component is activated.", factoryPid);
+        logger.info("Wren:IDM Info Service \"{}\" component is activated.", factoryPid);
     }
 
     @Deactivate
     protected void deactivate(ComponentContext context) {
         unregisterService();
         this.context = null;
-        logger.info("OpenIDM Info Service component is deactivated.");
+        logger.info("Wren:IDM Info Service component is deactivated.");
     }
 
     @Override

--- a/openidm-policy/src/main/java/org/forgerock/openidm/policy/PolicyService.java
+++ b/openidm-policy/src/main/java/org/forgerock/openidm/policy/PolicyService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2023 Wren Security
  */
 package org.forgerock.openidm.policy;
 
@@ -99,7 +99,7 @@ public class PolicyService extends AbstractScriptedService {
         setProperties(context);
         configuration = getConfiguration(context);
         registerService(context.getBundleContext(), configuration);
-        logger.info("OpenIDM Policy Service component is activated.");
+        logger.info("Wren:IDM Policy Service component is activated.");
     }
 
     /**
@@ -110,14 +110,14 @@ public class PolicyService extends AbstractScriptedService {
     void modified(ComponentContext context) throws Exception {
         configuration = getConfiguration(context);
         updateScriptHandler(configuration);
-        logger.info("OpenIDM Policy Service component is updateScriptHandler.");
+        logger.info("Wren:IDM Policy Service component is updateScriptHandler.");
     }
 
     @Deactivate
     protected void deactivate(ComponentContext context) {
         unregisterService();
         this.context = null;
-        logger.info("OpenIDM Policy Service component is deactivated.");
+        logger.info("Wren:IDM Policy Service component is deactivated.");
     }
 
     @Override

--- a/openidm-script/src/main/java/org/forgerock/openidm/script/AbstractScriptedService.java
+++ b/openidm-script/src/main/java/org/forgerock/openidm/script/AbstractScriptedService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
- * Portions Copyright 2018-2020 Wren Security.
+ * Portions Copyright 2020-2023 Wren Security.
  */
 package org.forgerock.openidm.script;
 
@@ -149,7 +149,7 @@ public abstract class AbstractScriptedService implements ScriptCustomizer, Scrip
                 getScriptRegistry().deleteScriptListener(scriptName, this);
             }
         }
-        logger.info("OpenIDM Info Service component is deactivated.");
+        logger.info("Wren:IDM Info Service component is deactivated.");
     }
 
     // ----- Implementation of ScriptListener interface

--- a/openidm-script/src/main/java/org/forgerock/openidm/script/impl/ScriptRegistryService.java
+++ b/openidm-script/src/main/java/org/forgerock/openidm/script/impl/ScriptRegistryService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2023 Wren Security
  */
 
 package org.forgerock.openidm.script.impl;
@@ -266,7 +266,7 @@ public class ScriptRegistryService extends ScriptRegistryImpl implements Request
         // Initialize the registry in ScriptUtil
         Scripts.init(this);
 
-        logger.info("OpenIDM Script Service component is activated.");
+        logger.info("Wren:IDM Script Service component is activated.");
     }
 
     @Modified
@@ -305,7 +305,7 @@ public class ScriptRegistryService extends ScriptRegistryImpl implements Request
         // Initialize the registry in ScriptUtil
         Scripts.init(this);
 
-        logger.info("OpenIDM Script Service component is modified.");
+        logger.info("Wren:IDM Script Service component is modified.");
     }
 
     @Deactivate
@@ -319,7 +319,7 @@ public class ScriptRegistryService extends ScriptRegistryImpl implements Request
         propertiesCache.clear();
         openidm.clear();
         setBindings(null);
-        logger.info("OpenIDM Script Service component is deactivated.");
+        logger.info("Wren:IDM Script Service component is deactivated.");
     }
 
     @Reference(
@@ -569,7 +569,7 @@ public class ScriptRegistryService extends ScriptRegistryImpl implements Request
         if (name instanceof String && StringUtils.isNotBlank(name)
                 && !reservedNames.contains(name)) {
             openidm.put(name, function);
-            logger.info("openidm.{} function is enabled", name);
+            logger.info("Wren:IDM.{} function is enabled", name);
         }
     }
 
@@ -579,7 +579,7 @@ public class ScriptRegistryService extends ScriptRegistryImpl implements Request
         if (name instanceof String && StringUtils.isNotBlank(name)
                 && !reservedNames.contains(name)) {
             openidm.remove(name, function);
-            logger.info("openidm.{} function is disabled", name);
+            logger.info("Wren:IDM.{} function is disabled", name);
         }
     }
 

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/ServerConstants.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/ServerConstants.java
@@ -23,7 +23,7 @@
  *
  *      Copyright 2006-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2010-2016 ForgeRock AS
- *      Portions Copyright 2018 Wren Security.
+ *      Portions Copyright 2018-2023 Wren Security.
  */
 package org.forgerock.openidm.core;
 
@@ -66,7 +66,7 @@ public final class ServerConstants {
     }
 
     public static String getDisplayVersion() {
-        StringBuilder sb = new StringBuilder("OpenIDM version \"")
+        StringBuilder sb = new StringBuilder("Wren:IDM version \"")
                 .append(getVersion())
                 .append("\" (revision: ")
                 .append(getRevision())


### PR DESCRIPTION
I used our product name (`Wren:IDM`) in status messages.

See snippet from startup:
```
Executing /opt/wrenidm/startup.sh...
Using OPENIDM_HOME:   /opt/wrenidm
Using PROJECT_HOME:   /opt/wrenidm
Using OPENIDM_OPTS:   -Xmx1024m -Xms1024m
Using LOGGING_CONFIG: -Djava.util.logging.config.file=/opt/wrenidm/conf/logging.properties
Using boot properties at /opt/wrenidm/conf/boot/boot.properties
-> ShellTUI: No standard input...exiting.
Wren:IDM ready
Wren:IDM version "6.2.0-SNAPSHOT" (revision: c91f1e9) update-status-messages
```