### PR TITLE
Fix Docker container graceful shutdown.

### DIFF
--- a/openidm-zip/src/main/resources/startup.sh
+++ b/openidm-zip/src/main/resources/startup.sh
@@ -155,14 +155,14 @@ cd "$PRGDIR"
 
 # start in normal mode
 START_IDM() {
-(java "$LOGGING_CONFIG" $JAVA_OPTS $COMPATIBILITY_OPTS $OPENIDM_OPTS \
+exec java "$LOGGING_CONFIG" $JAVA_OPTS $COMPATIBILITY_OPTS $OPENIDM_OPTS \
         -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
         -classpath "$CLASSPATH" \
         -Dopenidm.system.server.root="$OPENIDM_HOME" \
         -Djava.awt.headless=true \
         -Dcontent.types.user.table="$OPENIDM_HOME"/bin/content-types.properties \
         org.forgerock.commons.launcher.Main -c "$OPENIDM_HOME"/bin/launcher.json $CLOPTS \
-        -p "$PROJECT_HOME")
+        -p "$PROJECT_HOME"
 }
 
 while


### PR DESCRIPTION
Docker container created from the current Dockerfile cannot be gracefully shutdown by `SIGTERM`. Container is killed by `SIGKILL` after 10 seconds (default Docker configuration). It's because the container root process (`PID 1`) is shell that does not forward signals to the Wren:IDM Java process.

I changed the startup script to replace the shell process with a Wren:IDM Java process (via `Bash exec`).

Before:
![before](https://user-images.githubusercontent.com/13997406/213650834-f8e81b78-6b5d-475d-9144-236feb022205.png)

After:
![after](https://user-images.githubusercontent.com/13997406/213650990-73cdcfda-ebba-47ca-a73d-08bd5cf9d71d.png)


