### PR TITLE
Add fetching of task local variables.

### DIFF
--- a/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/mixin/HistoricProcessInstanceMixIn.java
+++ b/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/mixin/HistoricProcessInstanceMixIn.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyright 2024 Wren Security
  */
 package org.forgerock.openidm.workflow.activiti.impl.mixin;
 
@@ -25,7 +26,7 @@ import org.forgerock.openidm.workflow.activiti.ActivitiConstants;
 /**
  *
  */
-@JsonIgnoreProperties({"persistentState"})
+@JsonIgnoreProperties({"persistentState", "queryVariables"})
 public class HistoricProcessInstanceMixIn {
 
     @JsonProperty(ActivitiConstants.ACTIVITI_BUSINESSKEY)

--- a/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/mixin/HistoricTaskInstanceEntityMixIn.java
+++ b/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/mixin/HistoricTaskInstanceEntityMixIn.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2024 Wren Security
  */
 package org.forgerock.openidm.workflow.activiti.impl.mixin;
 
@@ -22,7 +23,7 @@ import org.forgerock.openidm.workflow.activiti.ActivitiConstants;
 
 import java.util.Date;
 
-@JsonIgnoreProperties({"persistentState"})
+@JsonIgnoreProperties({"persistentState", "queryVariables", "createTime"})
 public class HistoricTaskInstanceEntityMixIn {
 
 


### PR DESCRIPTION
This PR adds local variable fetching for workflow tasks.  See example below:

```json
{
  "_id" : "3725",
  "name" : "userRoleAssignment",
  "processVariables" : {
    "role" : "foobar"
  },
  "tasks" : [ {
    "_id" : "3744",
    "name" : "approvalByManager",
    "taskLocalVariables" : {
      "result" : "APPROVED"
    }
  }]
}
```
Before this change, the `taskLocakVariables` property is always empty.