### PR TITLE
Fix CodeMirror styles and replace removed jQuery size function

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/authentication/modules/OAUTH.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/authentication/modules/OAUTH.js
@@ -84,7 +84,6 @@ define([
                 this.model.iconCode = codemirror.fromTextArea(this.$el.find(".button-html")[0], {
                     lineNumbers: true,
                     viewportMargin: Infinity,
-                    theme: "forgerock",
                     mode: "xml",
                     htmlMode: true,
                     lineWrapping: true

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/authentication/modules/OPENID_CONNECT.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/authentication/modules/OPENID_CONNECT.js
@@ -112,7 +112,6 @@ define([
                 this.model.iconCode = codemirror.fromTextArea(this.$el.find(".button-html")[0], {
                     lineNumbers: true,
                     viewportMargin: Infinity,
-                    theme: "forgerock",
                     mode: "xml",
                     htmlMode: true,
                     lineWrapping: true

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/connector/ConnectorTypeAbstractView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/connector/ConnectorTypeAbstractView.js
@@ -202,7 +202,7 @@ define([
 
             $(clickedEle).parents(".form-group").remove();
 
-            if ($('#' + field_type + 'Wrapper').find('.field').size() === 1){
+            if ($('#' + field_type + 'Wrapper').find('.field').length === 1){
                 $('#' + field_type + 'Wrapper').find('.input-group-addon').hide();
             }
 

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/properties/EditPropertyMappingDialog.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/properties/EditPropertyMappingDialog.js
@@ -451,7 +451,7 @@ define([
 
                 isValid = _this.validateMapping();
 
-                if (isValid && initialRender !== "true" && $('#propertyMappingDialogForm').size() === 0){
+                if (isValid && initialRender !== "true" && $('#propertyMappingDialogForm').length === 0){
                     _this.formSubmit();
                 }
             });

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/selfservice/AbstractSelfServiceView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/selfservice/AbstractSelfServiceView.js
@@ -85,7 +85,6 @@ define([
                 lineNumbers: true,
                 autofocus: false,
                 viewportMargin: Infinity,
-                theme: "forgerock",
                 mode: "xml",
                 htmlMode: true,
                 lineWrapping: true

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/selfservice/SelfServiceStageDialogView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/selfservice/SelfServiceStageDialogView.js
@@ -58,7 +58,6 @@ define([
                 lineNumbers: true,
                 autofocus: false,
                 viewportMargin: Infinity,
-                theme: "forgerock",
                 mode: "xml",
                 htmlMode: true,
                 lineWrapping: true

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/selfservice/UserRegistrationConfigView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/selfservice/UserRegistrationConfigView.js
@@ -72,7 +72,6 @@ define([
                 lineNumbers: true,
                 autofocus: false,
                 viewportMargin: Infinity,
-                theme: "forgerock",
                 mode: "xml",
                 htmlMode: true,
                 lineWrapping: true

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/social/SocialConfigView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/social/SocialConfigView.js
@@ -368,7 +368,6 @@ define([
                         this.model.iconCode = codemirror.fromTextArea(dialogRef.$modalBody.find(".button-html")[0], {
                             lineNumbers: true,
                             viewportMargin: Infinity,
-                            theme: "forgerock",
                             mode: "xml",
                             htmlMode: true,
                             lineWrapping: true

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/util/InlineScriptEditor.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/util/InlineScriptEditor.js
@@ -132,7 +132,6 @@ define([
                         lineNumbers: true,
                         autofocus: this.model.autoFocus,
                         viewportMargin: Infinity,
-                        theme: "forgerock",
                         mode: mode
                     });
 


### PR DESCRIPTION
This PR introduces two fixes in the Admin UI:

* Use default styles for `CodeMirror`
* Replace removed `jQuery` size function