### PR TITLE
Remove invalid links in maven-javadoc-plugin configuration

### DIFF
--- a/openidm-servlet-registrator/pom.xml
+++ b/openidm-servlet-registrator/pom.xml
@@ -90,30 +90,6 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <author>false</author>
-                        <links>
-                            <link>http://docs.oracle.com/javase/6/docs/api/</link>
-                            <link>http://download.eclipse.org/jetty/stable-8/apidocs/</link>
-                        </links>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This PR removes invalid links in the `maven-javadoc-plugin` configuration. There is no need for the plugin management configuration, it is defined in the parent project.