### PR TITLE
Switch to UBI based Temurin image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,13 @@ RUN \
   unzip openidm-zip/target/wrenidm-$WRENIDM_VERSION.zip -d /build
 
 
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:17-jdk-ubi9-minimal
 
 # Create wrenidm user
 ARG WRENIDM_UID=1000
 ARG WRENIDM_GID=1000
-RUN addgroup --gid ${WRENIDM_GID} wrenidm && \
-    adduser --uid ${WRENIDM_UID} --gid ${WRENIDM_GID} --system wrenidm
+RUN groupadd --gid ${WRENIDM_GID} wrenidm && \
+    useradd --uid ${WRENIDM_UID} --gid ${WRENIDM_GID} --system wrenidm
 
 # Deploy wrenidm project
 COPY --chown=wrenidm:root --from=project-build /build/wrenidm /opt/wrenidm


### PR DESCRIPTION
This PR changes base Eclipse Temurin docker image from Ubuntu-based image to RedHat's Universal Base Image - Minimal.

Switching the base image to RPM based distro might pose a breaking change for downstream projects that use Wren:IDM image as their base image (i.e. `FROM wrensecurity/wrenidm:7.0.0}`). However if they want to use a different base image, they can simply use something along the lines of the following:

```Dockerfile
COPY --from=wrensecurity/wrenidm:7.0.0 /opt/wrenidm /opt/wrenidm
```

We might change it back to Ubuntu based image before the release if we discover any issues. I am creating this PR to have a record for this switch and a place where people can raise their complaints.