### PR TITLE
Fix mapping script global variable types.

### DIFF
--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncOperation.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncOperation.java
@@ -746,7 +746,7 @@ abstract class SyncOperation {
             Map<String, Object> scope = new HashMap<String, Object>();
             scope.put("context", context);
             scope.put("linkQualifier", getLinkQualifier());
-            scope.put("mappingConfig", objectMapping.getConfig());
+            scope.put("mappingConfig", objectMapping.getConfig().asMap());
             String sourceId = getSourceObjectId();
             String targetId = getTargetObjectId();
             // TODO: Once script engine can do on-demand get replace these forced loads

--- a/openidm-zip/src/main/resources/bin/defaults/script/roles/defaultPostMapping.groovy
+++ b/openidm-zip/src/main/resources/bin/defaults/script/roles/defaultPostMapping.groovy
@@ -27,11 +27,11 @@ def syncContext = context.containsContext(SyncContext.class) \
     ? context.asContext(SyncContext.class)
     : null;
 
-def mappingSource = mappingConfig.source.getObject() as String
+def mappingSource = mappingConfig.source as String
 def sourceObject = source as JsonValue
 def oldSource = oldSource as JsonValue
 
-mappingName =  mappingConfig.name.getObject() as String
+def mappingName =  mappingConfig.name as String
 
 try {
     if (!mappingSource.equals("managed/user") && syncContext == null) {


### PR DESCRIPTION
PR fixes global variable type of `mappingConfig` to be the raw value instead of being wrapped as `JsonValue`. This change will allow calling `defaultPostMapping.groovy` as eval action of `ScriptRegistryService`.