### PR TITLE
DRAFT: Use custom IdM identity service in Flowable for user's groups resolution.

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/util/WorkflowUtils.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/util/WorkflowUtils.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2024 Wren Security.
  */
 
 define([
@@ -99,14 +99,14 @@ define([
                         cssClass: "btn-primary",
                         action: function(dialogRef) {
                             var id = $("#candidateUsersSelect").val(),
-                                label = $("#candidateUsersSelect option:selected").text(),
+                                selectedUser = _.find(candidateUsers, { _id: id }),
                                 callback = function () {
                                     _this.render([_this.model.id], _.bind(function () {
                                         messagesManager.messages.addMessage({"message": $.t("templates.taskInstance.assignedSuccess")});
                                     }, this));
                                 };
 
-                            obj.assignTask(_this.model, id, label, callback);
+                            obj.assignTask(_this.model, selectedUser, callback);
                             dialogRef.close();
                         }
                     }
@@ -118,18 +118,17 @@ define([
          * sets the assignee attribute on a taskinstance
          *
          * @param model {a taskinstance model}
-         * @id {the new assignee id to be set}
-         * @label {the username text to be displayed in the nonCandidateWarning}
+         * @user {object representing the new assignee user to be set}
          * @successCallback
          * @returns {nothing}
          * @constructor
          */
-        obj.assignTask = function(model, id, label, successCallback) {
+        obj.assignTask = function(model, user, successCallback) {
             var assignNow = function () {
-                model.set("assignee",id);
+                model.set("assignee", user._id);
 
-                if (id === "noUserAssigned") {
-                    model.set("assignee",null);
+                if (user._id === "noUserAssigned") {
+                    model.set("assignee", null);
                 }
 
                 model.save().then(successCallback);
@@ -139,8 +138,8 @@ define([
              * before changing assignee alert the "assigner" that the user
              * being assigned does not exist in the list of candidate users
              */
-            if (id !== "noUserAssigned" && !_.includes(model.get("candidates").candidateUsers, id)) {
-                UIUtils.jqConfirm($.t("templates.taskInstance.nonCanditateWarning",{ userName: label }), _.bind(function() {
+            if (user._id !== "noUserAssigned" && !_.includes(model.get("candidates").candidateUsers, user.userName)) {
+                UIUtils.jqConfirm($.t("templates.taskInstance.nonCanditateWarning",{ userName: user.userName }), _.bind(function() {
                     assignNow();
                 }, this));
             } else {

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ProcessHistoryView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ProcessHistoryView.js
@@ -163,7 +163,7 @@ define([
                                 displayName = (item.displayName) ? item.displayName : item.givenName + " " + item.sn;
 
 
-                            return '<divclass="option">' +
+                            return '<div class="option">' +
                                 '<span class="user-title">' +
                                 '<span class="user-fullname">' + escape(displayName) + userName + '</span>' +
                                 '</span>' +
@@ -176,7 +176,7 @@ define([
                         if (!query.length) {
                             queryFilter = "userName sw \"\" &_pageSize=10";
                         } else {
-                            queryFilter = "givenName sw \"" +query +"\" or sn sw \"" +query +"\" or userName sw \"" +query +"\"";
+                            queryFilter = "givenName sw \"" + query +"\" or sn sw \"" + query +"\" or userName sw \"" + query +"\"";
                         }
 
                         ResourceDelegate.searchResource(queryFilter, "managed/user").then(function(search) {

--- a/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/workflow/tasks/TasksMenuView.js
+++ b/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/workflow/tasks/TasksMenuView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2024 Wren Security.
  */
 
 define([
@@ -262,8 +262,8 @@ define([
                 task = this.getTaskFromCacheById($(target).closest("tr").find("input[name=taskId]").val());
 
                 if (task) {
-                    for (i = 0; i < task.usersToAssign.users.length; i++) {
-                        user = task.usersToAssign.users[i];
+                    for (i = 0; i < task.usersToAssign.length; i++) {
+                        user = task.usersToAssign[i];
 
                         if ($(target).find("option[value='"+ user.username +"']").length === 0 && user.username !== conf.loggedUser.get("userName")) {
                             $(target).append('<option value="'+ user.username +'">'+ user.displayableName +'</option');

--- a/openidm-zip/src/main/resources/bin/defaults/script/router-authz.js
+++ b/openidm-zip/src/main/resources/bin/defaults/script/router-authz.js
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * 
+ * Portions Copyrighted 2024 Wren Security
  */
 
 /*
@@ -124,49 +126,24 @@ function join (arr, delim) {
 }
 
 function isUserCandidateForTask(taskInstanceId) {
-
-    var userCandidateTasksQueryParams = {
+    const params = {
             "_queryId": "filtered-query",
+            "taskId": taskInstanceId,
             "taskCandidateUser": context.security.authenticationId
-        },
-        userCandidateTasks = openidm.query("workflow/taskinstance", userCandidateTasksQueryParams).result,
-        userGroupCandidateTasksQueryParams,
-        userGroupCandidateTasks,
-        i,roles,role;
-
-    for (i = 0; i < userCandidateTasks.length; i++) {
-        if (taskInstanceId === userCandidateTasks[i]._id) {
-            return true;
-        }
     }
-
-    roles = "";
-    for (i = 0; i < context.security.authorization.roles.length; i++) {
-        role = context.security.authorization.roles[i];
-        if (i === 0) {
-            roles = role;
-        } else {
-            roles = roles + "," + role;
-        }
-    }
-
-    userGroupCandidateTasksQueryParams = {
-        "_queryId": "filtered-query",
-        "taskCandidateGroup": ((typeof roles === "string") ? roles : join(roles, ","))
-    };
-    userGroupCandidateTasks = openidm.query("workflow/taskinstance", userGroupCandidateTasksQueryParams).result;
-    for (i = 0; i < userGroupCandidateTasks.length; i++) {
-        if (taskInstanceId === userGroupCandidateTasks[i]._id) {
-            return true;
-        }
-    }
-
-    return false;
+    const tasks = openidm.query("workflow/taskinstance", params).result;
+    return tasks.length > 0;
 }
 
 function canUpdateTask() {
-    var taskInstanceId = request.resourcePath.split("/")[2];
-    return isMyTask() || isUserCandidateForTask(taskInstanceId);
+    const taskInstanceId = request.resourcePath.split("/")[2];
+    const params = {
+            "_queryId": "filtered-query",
+            "taskId": taskInstanceId,
+            "taskCandidateOrAssigned": context.security.authenticationId
+    }
+    const tasks = openidm.query("workflow/taskinstance", params).result;
+    return tasks.length > 0;
 }
 
 function isProcessOnUsersList(processFilter) {

--- a/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/WorkflowConstants.java
+++ b/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/WorkflowConstants.java
@@ -62,6 +62,7 @@ public class WorkflowConstants {
     public static final String EXECUTION_ID_ATTR = "executionId";
     public static final String CANDIDATE_GROUP_ATTR = "taskCandidateGroup";
     public static final String CANDIDATE_USER_ATTR = "taskCandidateUser";
+    public static final String CANDIDATE_OR_ASSIGNED_ATTR = "taskCandidateOrAssigned";
     public static final String START_USER_ID_ATTR = "startUserId";
     public static final String SUPER_PROCESS_INSTANCE_ID_ATTR = "superProcessInstanceId";
     public static final String TASK_ID_ATTR = "taskId";

--- a/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/identity/IdmEngineConfigurator.java
+++ b/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/identity/IdmEngineConfigurator.java
@@ -1,0 +1,49 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License (the License). You may not use this file except in
+ * compliance with the License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License
+ * for the specific language governing permission and limitations under the
+ * License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each
+ * file and include the License file at legal/CDDLv1.0.txt. If applicable, add
+ * the following below the CDDL Header, with the fields enclosed by brackets []
+ * replaced by your own identifying information:
+ * "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2024 Wren Security.
+ */
+package org.wrensecurity.wrenidm.workflow.flowable.impl.identity;
+
+import org.flowable.common.engine.impl.AbstractEngineConfiguration;
+import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
+import org.flowable.idm.engine.IdmEngineConfiguration;
+import org.forgerock.json.resource.ConnectionFactory;
+
+public class IdmEngineConfigurator extends org.flowable.idm.engine.configurator.IdmEngineConfigurator {
+
+    private ConnectionFactory connectionFactory;
+
+    public IdmEngineConfigurator(ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    @Override
+    public void beforeInit(AbstractEngineConfiguration engineConfiguration) {
+        // Nothing to do
+    }
+
+    @Override
+    public void configure(AbstractEngineConfiguration engineConfiguration) {
+        super.configure(engineConfiguration);
+
+        getIdmEngineConfiguration(engineConfiguration)
+            .setIdmIdentityService(new IdmIdentityService(connectionFactory, idmEngineConfiguration));
+    }
+
+    protected static IdmEngineConfiguration getIdmEngineConfiguration(AbstractEngineConfiguration engineConfiguration) {
+        return (IdmEngineConfiguration) engineConfiguration.getEngineConfigurations().get(EngineConfigurationConstants.KEY_IDM_ENGINE_CONFIG);
+    }
+}

--- a/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/identity/IdmIdentityService.java
+++ b/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/identity/IdmIdentityService.java
@@ -20,36 +20,44 @@ package org.wrensecurity.wrenidm.workflow.flowable.impl.identity;
 
 import java.util.List;
 import org.flowable.common.engine.impl.identity.Authentication;
-import org.flowable.engine.IdentityService;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.GroupQuery;
 import org.flowable.idm.api.NativeGroupQuery;
+import org.flowable.idm.api.NativeTokenQuery;
 import org.flowable.idm.api.NativeUserQuery;
 import org.flowable.idm.api.Picture;
+import org.flowable.idm.api.Privilege;
+import org.flowable.idm.api.PrivilegeMapping;
+import org.flowable.idm.api.PrivilegeQuery;
+import org.flowable.idm.api.Token;
+import org.flowable.idm.api.TokenQuery;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
+import org.flowable.idm.engine.IdmEngineConfiguration;
+import org.flowable.idm.engine.impl.IdmIdentityServiceImpl;
 import org.forgerock.json.resource.Connection;
 import org.forgerock.json.resource.ConnectionFactory;
 import org.forgerock.json.resource.ResourceException;
 
-public class IdmIdentityService implements IdentityService {
+public class IdmIdentityService extends IdmIdentityServiceImpl {
 
-    public static final String ID_ATTR = "id";
+    public static final String ID_ATTR = "_id";
     public static final String NAME_ATTR = "name";
     public static final String USERNAME_ATTR = "userName";
     public static final String GIVEN_NAME_ATTR = "givenName";
     public static final String SURNAME_ATTR = "sn";
     public static final String MAIL_ATTR = "mail";
+    public static final String MEMBERS_ATTR = "members";
 
     private ConnectionFactory connectionFactory;
 
-    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+    public IdmIdentityService(ConnectionFactory connectionFactory, IdmEngineConfiguration idmEngineConfiguration) {
+        super(idmEngineConfiguration);
         this.connectionFactory = connectionFactory;
     }
 
-    @Override
-    public UserQuery createUserQuery() {
-        return new IdmUserQuery(getConnection());
+    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
     }
 
     @Override
@@ -62,69 +70,36 @@ public class IdmIdentityService implements IdentityService {
         Authentication.setAuthenticatedUserId(userId);
     }
 
+    // User related unsupported methods
+
+    @Override
+    public UserQuery createUserQuery() {
+        throw new UnsupportedOperationException("Creating user query is not supported.");
+    }
+
     @Override
     public NativeUserQuery createNativeUserQuery() {
-        throw new UnsupportedOperationException("Native user query is not supported.");
+        throw new UnsupportedOperationException("Creating native user query is not supported.");
     }
 
     @Override
     public User newUser(String userId) {
-        throw new UnsupportedOperationException("User creation is not supported.");
+        throw new UnsupportedOperationException("Creating user is not supported.");
     }
 
     @Override
     public void saveUser(User user) {
-        throw new UnsupportedOperationException("User creation is not supported.");
+        throw new UnsupportedOperationException("Saving user is not supported.");
     }
 
     @Override
     public void updateUserPassword(User user) {
-        throw new UnsupportedOperationException("User password update is not supported.");
+        throw new UnsupportedOperationException("Updating user password is not supported.");
     }
 
     @Override
     public void deleteUser(String userId) {
-        throw new UnsupportedOperationException("User deletion is not supported.");
-    }
-
-    @Override
-    public Group newGroup(String groupId) {
-        throw new UnsupportedOperationException("Group creation is not supported.");
-    }
-
-    @Override
-    public NativeGroupQuery createNativeGroupQuery() {
-        throw new UnsupportedOperationException("Native group query is not supported.");
-    }
-
-    @Override
-    public List<Group> getPotentialStarterGroups(String processDefinitionId) {
-        throw new UnsupportedOperationException("Getting of potential starter groups is not supported.");
-    }
-
-    @Override
-    public List<User> getPotentialStarterUsers(String processDefinitionId) {
-        throw new UnsupportedOperationException("Getting of potential starter users is not supported.");
-    }
-
-    @Override
-    public void saveGroup(Group group) {
-        throw new UnsupportedOperationException("Group creation is not supported.");
-    }
-
-    @Override
-    public void deleteGroup(String groupId) {
-        throw new UnsupportedOperationException("Group deletion is not supported.");
-    }
-
-    @Override
-    public void createMembership(String userId, String groupId) {
-        throw new UnsupportedOperationException("Membership creation is not supported.");
-    }
-
-    @Override
-    public void deleteMembership(String userId, String groupId) {
-        throw new UnsupportedOperationException("Membership deletion is not supported.");
+        throw new UnsupportedOperationException("Deleting user is not supported.");
     }
 
     @Override
@@ -134,32 +109,143 @@ public class IdmIdentityService implements IdentityService {
 
     @Override
     public void setUserPicture(String userId, Picture picture) {
-        throw new UnsupportedOperationException("Setting of user picture is not supported.");
+        throw new UnsupportedOperationException("Setting user picture is not supported.");
     }
 
     @Override
     public Picture getUserPicture(String userId) {
-        throw new UnsupportedOperationException("Getting of user picture is not supported.");
+        throw new UnsupportedOperationException("Getting user picture is not supported.");
     }
 
     @Override
     public void setUserInfo(String userId, String key, String value) {
-        throw new UnsupportedOperationException("Setting of user info is not supported.");
+        throw new UnsupportedOperationException("Setting user info is not supported.");
     }
 
     @Override
     public String getUserInfo(String userId, String key) {
-        throw new UnsupportedOperationException("Getting of user info is not supported.");
+        throw new UnsupportedOperationException("Getting user info is not supported.");
     }
 
     @Override
     public List<String> getUserInfoKeys(String userId) {
-        throw new UnsupportedOperationException("Getting of user info keys is not supported.");
+        throw new UnsupportedOperationException("Getting user info keys is not supported.");
     }
 
     @Override
     public void deleteUserInfo(String userId, String key) {
-        throw new UnsupportedOperationException("Deleting of user info is not supported.");
+        throw new UnsupportedOperationException("Deleting user info is not supported.");
+    }
+
+    // Group related unsupported methods
+
+    @Override
+    public Group newGroup(String groupId) {
+        throw new UnsupportedOperationException("Creating group is not supported.");
+    }
+
+    @Override
+    public NativeGroupQuery createNativeGroupQuery() {
+        throw new UnsupportedOperationException("Creating native group query is not supported.");
+    }
+
+    @Override
+    public void saveGroup(Group group) {
+        throw new UnsupportedOperationException("Saving group is not supported.");
+    }
+
+    @Override
+    public void deleteGroup(String groupId) {
+        throw new UnsupportedOperationException("Deleting group is not supported.");
+    }
+
+    @Override
+    public void createMembership(String userId, String groupId) {
+        throw new UnsupportedOperationException("Creating membership is not supported.");
+    }
+
+    @Override
+    public void deleteMembership(String userId, String groupId) {
+        throw new UnsupportedOperationException("Deleting membership is not supported.");
+    }
+
+    // Privilege related unsupported methods
+
+    @Override
+    public Privilege createPrivilege(String name) {
+        throw new UnsupportedOperationException("Creating privilege is not supported.");
+    }
+
+    @Override
+    public void addUserPrivilegeMapping(String privilegeId, String userId) {
+        throw new UnsupportedOperationException("Creating user privilege mapping is not supported.");
+    }
+
+    @Override
+    public void deleteUserPrivilegeMapping(String privilegeId, String userId) {
+        throw new UnsupportedOperationException("Deleting user privilege mapping is not supported.");
+    }
+
+    @Override
+    public void addGroupPrivilegeMapping(String privilegeId, String groupId) {
+        throw new UnsupportedOperationException("Creating group privilege mapping is not supported.");
+    }
+
+    @Override
+    public void deleteGroupPrivilegeMapping(String privilegeId, String groupId) {
+        throw new UnsupportedOperationException("Deleting group privilege mapping is not supported.");
+    }
+
+    @Override
+    public List<PrivilegeMapping> getPrivilegeMappingsByPrivilegeId(String privilegeId) {
+        throw new UnsupportedOperationException("Getting privilege mappings is not supported.");
+    }
+
+    @Override
+    public void deletePrivilege(String id) {
+        throw new UnsupportedOperationException("Deleting privilege is not supported.");
+    }
+
+    @Override
+    public PrivilegeQuery createPrivilegeQuery() {
+        throw new UnsupportedOperationException("Creating privilege query is not supported.");
+    }
+
+    @Override
+    public List<Group> getGroupsWithPrivilege(String name) {
+        throw new UnsupportedOperationException("Getting groups with privileges is not supported.");
+    }
+
+    @Override
+    public List<User> getUsersWithPrivilege(String name) {
+        throw new UnsupportedOperationException("Getting users with privileges is not supported.");
+    }
+
+    // Token related unsupported methods
+
+    @Override
+    public Token newToken(String tokenId) {
+        throw new UnsupportedOperationException("Creating token is not supported.");
+    }
+
+    @Override
+    public void saveToken(Token token) {
+        throw new UnsupportedOperationException("Saving token is not supported.");
+    }
+
+    @Override
+    public void deleteToken(String tokenId) {
+        throw new UnsupportedOperationException("Deleting token is not supported.");
+    }
+
+    @Override
+    public TokenQuery createTokenQuery() {
+        throw new UnsupportedOperationException("Creating token query is not supported.");
+    }
+
+    @Override
+    public NativeTokenQuery createNativeTokenQuery() {
+        throw new UnsupportedOperationException("Creating native token query is not supported.");
     }
 
     /**

--- a/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/identity/IdmUserQuery.java
+++ b/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/identity/IdmUserQuery.java
@@ -49,6 +49,7 @@ public class IdmUserQuery extends UserQueryImpl {
 
     @Override
     public List<User> executeList(CommandContext commandContext) {
+        // FIXME: handle filtering
         QueryRequest request = Requests.newQueryRequest("managed/user");
         request.setQueryId(WorkflowConstants.QUERY_ALL_IDS);
         List<User> result = new ArrayList<>();
@@ -63,6 +64,7 @@ public class IdmUserQuery extends UserQueryImpl {
 
     @Override
     public long executeCount(CommandContext commandContext) {
+        // FIXME: handle filtering
         try {
             QueryRequest request = Requests.newQueryRequest("managed/user");
             if (getId() == null) {

--- a/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/resource/TaskInstanceResource.java
+++ b/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/resource/TaskInstanceResource.java
@@ -306,6 +306,9 @@ public class TaskInstanceResource implements CollectionResourceProvider {
                 case WorkflowConstants.CANDIDATE_USER_ATTR:
                     query.taskCandidateUser(param.getValue());
                     break;
+                case WorkflowConstants.CANDIDATE_OR_ASSIGNED_ATTR:
+                    query.taskCandidateOrAssigned(param.getValue());
+                    break;
                 case WorkflowConstants.RESOURCE_ID:
                     query.taskId(param.getValue());
                     break;

--- a/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/resource/TaskInstanceResource.java
+++ b/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/resource/TaskInstanceResource.java
@@ -309,7 +309,7 @@ public class TaskInstanceResource implements CollectionResourceProvider {
                 case WorkflowConstants.CANDIDATE_OR_ASSIGNED_ATTR:
                     query.taskCandidateOrAssigned(param.getValue());
                     break;
-                case WorkflowConstants.RESOURCE_ID:
+                case WorkflowConstants.TASK_ID_ATTR:
                     query.taskId(param.getValue());
                     break;
                 case WorkflowConstants.NAME_ATTR:


### PR DESCRIPTION
* IdM identity service for Flowable (former Activiti) has existed in Wren:IDM for some time, but it was never used. This PR refactors the service and group query implementation and enables usage of custom IdM service.
* IdM service refactor is based on Flowable's implementation of LDAP IdM identity service ([flowable-ldap module](https://github.com/flowable/flowable-engine/tree/main/modules/flowable-ldap), [flowable-ldap-configurator module](https://github.com/flowable/flowable-engine/tree/main/modules/flowable-ldap-configurator)).
* Former group query implementation ignored filtering parameters. Not all parameters are supported. Only parameters that might be used by Flowable's internals or parameters used by Wren:IDM are supported.
* Main use case for these changes is letting Flowable handle resolution of group members when deciding whether user is a task candidate or not. We no longer need to check user's authzRoles and compare them with task's candidate groups manually. This is reflected by changes in `router-authz.js`, `getavailableuserstoassign.js` and `gettasksview.js`.

Other notable changes:

* `endpoint/getavailableuserstoassign` now should be called as `query` instead of `action`. The only script that calls this endpoint is `gettasksview.js` that incorrectly called it as query, which I think does make sense. Format of the response also changed: `{ users: [<users>], assignee: <assignee>` -> `[<users>]`. Assignee property has not been used anywhere so I don't think it needs to preserved. Task's assignee is always available in the task instance object anyway.
* `endpoint/gettasksview` and custom authz functions `canUpdateTask` and `isUserCandidateForTask` no longer use user's authorization roles from security context to compare them with task instance's candidate groups. Instead, task instance resource is queried with appropriate query parameters (`taskCandidateUser`, `taskCandidateOrAssignee`) and Flowable will decide whether user is a candidate or not based on user's `roles` (reverse attribute for managed role's `members` attribute).
* User query used by IdM identity service has been disabled (throws error if used) since it is not used by Wren:IDM nor Flowable's internals (in Wren:IDM's use cases). I have not deleted IdmUserQuery.java, but I think we should consider it.

There are also some minor fixes that might be separated to another PR if desired.