### PR TITLE
Treat NULL values in mapped tables as undefined

### DIFF
--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/mapper/MappedResultMapper.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/mapper/MappedResultMapper.java
@@ -106,7 +106,10 @@ public class MappedResultMapper implements ResultMapper<Map<String, Object>> {
                 default:
                     throw new InternalServerErrorException("Unsupported DB column type " + config.valueType);
             }
-            result.putPermissive(config.propertyName, value);
+            // treat NULL as undefined
+            if (value != null) {
+                result.putPermissive(config.propertyName, value);
+            }
         }
         return result.asMap();
     }


### PR DESCRIPTION
This changes the way how `NULL` values in mapped table columns are handled - all `NULL` values are being treated as `undefined` JSON values.

This change makes sense as it aligns generic table behavior with the explicitly mapped behavior. However this also makes it impossible to actually save `null` values, but supporting `undefined` is definitely a more reasonable default. This needs to be properly tested before merging (i.e. no phantom changes when working with Admin UI and during synchronization).