### PR TITLE
Remove unused env variable from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN \
 # Configure headless Chromium for Puppeteer
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
-# Use '--no-sandbox' option for Puppeteer's Chromium because of incompatibility with Docker
-ENV DISABLE_PUPPETEER_SANDBOX=true
 
 # Copy project files
 WORKDIR /project


### PR DESCRIPTION
This PR removes environment variable DISABLE_PUPPETEER_SANDBOX declaration. The variable is not being used since rev. 0f02741859317effc55d59c022f9395e38e5dc89.