### PR TITLE
Fix handling of workflow participants.

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/util/WorkflowUtils.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/util/WorkflowUtils.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions Copyright 2023-2024 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -127,7 +127,7 @@ define([
          */
         obj.assignTask = function(model, user, successCallback) {
             var assignNow = function () {
-                model.set("assignee", user._id);
+                model.set("assignee", user.userName);
 
                 if (user._id === "noUserAssigned") {
                     model.set("assignee", null);

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ActiveProcessesView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ActiveProcessesView.js
@@ -142,7 +142,7 @@ define([
                 this.model.processes.getFirstPage();
 
                 this.$el.find("#processAssignedTo").selectize({
-                    valueField: '_id',
+                    valueField: 'userName',
                     labelField: 'userName',
                     searchField: ["userName","givenName", "sn"],
                     create: false,
@@ -196,7 +196,7 @@ define([
 
                 this.$el.find("#processAssignedTo")[0].selectize.addOption({
                     _id : "anyone",
-                    userName: "Anyone",
+                    userName: "anyone",
                     givenName : "Anyone",
                     sn : ""
                 });

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/TaskListView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/TaskListView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -140,7 +140,7 @@ define([
                 Tasks.getFirstPage();
 
                 this.$el.find("#taskAssignedTo").selectize({
-                    valueField: '_id',
+                    valueField: 'userName',
                     labelField: 'userName',
                     searchField: ["given", "sn", "userName"],
                     create: false,
@@ -199,8 +199,8 @@ define([
                     }, this)
                 });
 
-                this.$el.find("#taskAssignedTo")[0].selectize.addOption({_id : "anyone", userName: "", displayName : $.t("templates.workflows.tasks.anyone")});
-                this.$el.find("#taskAssignedTo")[0].selectize.addOption({_id : "unassigned", userName: "", displayName : $.t("templates.workflows.tasks.unassigned")});
+                this.$el.find("#taskAssignedTo")[0].selectize.addOption({_id : "anyone", userName: "anyone", displayName : $.t("templates.workflows.tasks.anyone")});
+                this.$el.find("#taskAssignedTo")[0].selectize.addOption({_id : "unassigned", userName: "unassigned", displayName : $.t("templates.workflows.tasks.unassigned")});
 
                 this.$el.find("#taskAssignedTo")[0].selectize.setValue("anyone");
 

--- a/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/ProcessInstanceViewTemplate.html
+++ b/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/ProcessInstanceViewTemplate.html
@@ -14,7 +14,7 @@
                     {{t "templates.processInstance.process" }}
                     <span class="meta">
                         <span class="meta-icon-bullet"><i class="fa fa-clock-o"></i> {{t "templates.processInstance.created" }}: {{date processInstance.startTime "MMM d, yyyy  h:mm:ss TT"}}</span>
-                        {{t "templates.processInstance.by" }} <a href="#resource/managed/user/edit/{{startedBy._id}}/">{{startedBy.givenName}} {{startedBy.sn}}</a></span>
+                        {{t "templates.processInstance.by" }} <a href="#resource/managed/user/edit/{{startedBy._id}}">{{startedBy.givenName}} {{startedBy.sn}}</a></span>
                     </span>
                 </h4>
                 <div class="page-header-button-group">

--- a/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/TaskInstanceViewTemplate.html
+++ b/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/TaskInstanceViewTemplate.html
@@ -105,7 +105,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="media-body media-middle">
-                                                    <a href="#resource/managed/user/edit/{{task.assignee}}/">{{assignee.givenName}} {{assignee.sn}} <small class="text-muted">({{assignee.userName}})</small></a>
+                                                    <a href="#resource/managed/user/edit/{{assignee._id}}">{{assignee.givenName}} {{assignee.sn}} <small class="text-muted">({{assignee.userName}})</small></a>
                                                     <button id="assigneeTaskBtnUser_{{task.assignee}}" class="btn btn-default btn-xs assignTask">{{t "templates.taskInstance.reassign" }}</button>
                                                 </div>
                                             </div>

--- a/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/workflow/WorkflowDelegate.js
+++ b/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/workflow/WorkflowDelegate.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -126,6 +126,19 @@ define([
                     errorCallback();
                 } else if (successCallback) {
                     successCallback(data.result[0]);
+                }
+            },
+            error: errorCallback
+        });
+    };
+
+    obj.fetchUser = function(username, successCallback, errorCallback) {
+        obj.serviceCall({
+            url : '/openidm/managed/user?_queryId=for-userName&uid=' + encodeURIComponent(username) + '&_fields=_id,givenName,sn,userName',
+            type: 'GET',
+            success: function(data) {
+                if (successCallback) {
+                    successCallback(data);
                 }
             },
             error: errorCallback


### PR DESCRIPTION
This PR fixes the fetching of workflow participants (assignee, initiator) in the admin UI. It is assumed that the reference to the user is a username. This assumption is compliant with the workflow module (e.g. https://github.com/WrenSecurity/wrenidm/blob/b2ea888ab97d6c370bb49451dd7bc9bb5dccc3f3/wrenidm-workflow-flowable/src/main/java/org/wrensecurity/wrenidm/workflow/flowable/impl/resource/ProcessInstanceResource.java#L152).