### PR TITLE
Fix form tooltip

### DIFF
--- a/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/resource/GenericEditResourceView.js
+++ b/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/resource/GenericEditResourceView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -304,7 +304,7 @@ define([
                 // this text escaped since it's being inserted into an attribute
                 let tipDescription = _.escape($(this).text());
                 let iconElement = $('<i class="fa fa-info-circle info" title="'+ tipDescription+'"/>');
-                $(this).parent().find("label").after(iconElement);
+                $(this).parent().find("label").append(' ').append(iconElement);
                 $(this).empty();
             });
 


### PR DESCRIPTION
This PR fixes a broken tooltip in the edit resource form.

Before:
![old](https://github.com/user-attachments/assets/e5734b27-2c39-450f-ba8a-1bebbf1fafba)

After:
![new](https://github.com/user-attachments/assets/84e04e9a-15a9-42ab-8eb4-75388cacf07a)
