### PR TITLE
Fix workflow datasource manipulation

### DIFF
--- a/wrenidm-workflow-flowable/pom.xml
+++ b/wrenidm-workflow-flowable/pom.xml
@@ -108,11 +108,6 @@
             <version>1.10.3</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-        </dependency>
-
         <!-- Provided OSGi Dependencies -->
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
~This PR introduces two changes to the workflow data source.
First, at least one data source reference is now required. Second, to use the local H2 file as a workflow repository, you must use the "h2:embedded" key.~

This PR completely removes support for embedded H2 as a workflow repository.

In the old version, you may end up with the OSGi reference race condition and as a result the H2 file workflow repository is used. And it is performed completely silent, no information is logged.