### PR TITLE
Upgrade odata-client-core to 4.10.0

### DIFF
--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -611,7 +611,7 @@
         <dependency>
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-client-core</artifactId>
-            <version>4.0.0-beta-01</version>
+            <version>4.10.0</version>
 
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This PR upgrades `odata-client-core` dependency to resolve the security vulnerabilities. This dependency is used in the Azure integration sample Groovy scripts (e.g. https://github.com/WrenSecurity/wrenicf-groovy-connector/blob/8f8b4b2dfe022c60cc8dbbc8575d15de05e276bb/src/test/resources/azure_ad/shared/ODataUtils.groovy) and probably does not need to be bundled by default. It might be enough to write the necessity of placing the library on the classpath in the README of the sample. I will create an issue for further discussion.