### PR TITLE
Fix paging in role-related queries

### DIFF
--- a/openidm-zip/src/main/resources/bin/defaults/script/roles/conditionalRoles.js
+++ b/openidm-zip/src/main/resources/bin/defaults/script/roles/conditionalRoles.js
@@ -238,7 +238,7 @@
         pagedResultsCookie = "";
         do {
             queryResult = getUserSet(query, pageSize, pagedResultsCookie);
-            pagedResultsCookie = queryResult._pagedResultsCookie;
+            pagedResultsCookie = queryResult.pagedResultsCookie;
             currentConditionalMembers = callbackFunction(queryResult.result, currentConditionalMembers);
 
         } while (pagedResultsCookie);

--- a/openidm-zip/src/main/resources/bin/defaults/script/roles/temporalConstraints.js
+++ b/openidm-zip/src/main/resources/bin/defaults/script/roles/temporalConstraints.js
@@ -35,7 +35,7 @@
 
         do {
             queryResult = getRolesWithTemporalConstraints(pageSize, pagedResultsCookie);
-            pagedResultsCookie = queryResult._pagedResultsCookie;
+            pagedResultsCookie = queryResult.pagedResultsCookie;
             rolesWithExpiredConstraints = rolesWithExpiredConstraints
                 .concat(queryResult.result.filter(areRoleConstraintsExpired));
         } while (pagedResultsCookie);


### PR DESCRIPTION
This PR fixes name of the cookie property in the role-related queries. The correct name is `pagedResultsCookie` (https://github.com/WrenSecurity/wrenidm/blob/main/openidm-script/src/main/java/org/forgerock/openidm/script/ResourceFunctions.java#L615).