### PR TITLE
Add context into policy action script

### DIFF
--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/Policy.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/Policy.java
@@ -134,6 +134,7 @@ class Policy {
         }
         if (script != null) { // action is dynamically determined
             Map<String, Object> scope = new HashMap<String, Object>();
+            scope.put("context", context);
             Map<String, Object> recon = new HashMap<String, Object>();
             scope.put("recon", recon);
             JsonValue actionParam = syncOperation.toJsonValue();


### PR DESCRIPTION
This PR adds `context` to the policy's `action` script.