### PR TITLE
Remove orientdb repo config support from Admin UI (#118)

### DIFF
--- a/openidm-external-rest/src/main/javadoc/overview.html
+++ b/openidm-external-rest/src/main/javadoc/overview.html
@@ -11,6 +11,6 @@
   </style>
 </head>
 <body>
-<p class="p1">OpenIDM repository using OrientDB.</p>
+<p class="p1">OpenIDM repository.</p>
 </body>
 </html>

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/delegates/RepoDelegate.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/delegates/RepoDelegate.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 
 define([
@@ -28,13 +29,13 @@ define([
     var obj = Object.create(ConfigDelegate);
 
     /**
-     * Queries the config store for a single entry which starts with "repo."
+     * Get repository config. The JDBC repository is currently the only supported type.
      */
-    obj.findRepoConfig = function() {
+    obj.getRepoConfig = function() {
         return obj.serviceCall({
-            url: "?_queryFilter=_id sw 'repo.'",
+            url: "/repo.jdbc",
             type: "GET"
-        }).then((response) => response.result[0]);
+        }).then((response) => response);
     };
 
     /**
@@ -43,39 +44,6 @@ define([
     obj.getRepoTypeFromConfig = function(config) {
         return config._id.replace('repo.', '');
     };
-
-    obj.deleteManagedObject = function (config, managedObjectName) {
-        if (obj.getRepoTypeFromConfig(config) === "orientdb") {
-            config = obj.removeManagedObjectFromOrientClasses(config, managedObjectName);
-            return obj.updateEntity(config._id, config);
-        } else {
-            return $.Deferred().resolve();
-        }
-    };
-
-    obj.addManagedObjectToOrientClasses = function(config, managedObjectName) {
-        var orientClasses = config.dbStructure.orientdbClass;
-
-        if (_.isUndefined(orientClasses["managed_" + managedObjectName])) {
-            orientClasses["managed_" + managedObjectName] = {
-                "index" : [
-                    {
-                        "propertyName" : "_openidm_id",
-                        "propertyType" : "string",
-                        "indexType" : "unique"
-                    }
-                ]
-            };
-        }
-        return config;
-    };
-
-    obj.removeManagedObjectFromOrientClasses = function(config, managedObjectName) {
-        var orientClasses = config.dbStructure.orientdbClass;
-        delete orientClasses["managed_" + managedObjectName];
-        return config;
-    };
-
 
     /**
      * Returns a reference to the appropriate resource mapping section of the config

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/AbstractManagedView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/AbstractManagedView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -53,10 +53,6 @@ define([
             promises.push(ConfigDelegate.updateEntity("managed", {"objects" : saveObject.objects}));
 
             switch (RepoDelegate.getRepoTypeFromConfig(this.data.repoConfig)) {
-                case "orientdb":
-                    this.data.repoConfig = RepoDelegate.addManagedObjectToOrientClasses(this.data.repoConfig, managedObject.name);
-                    promises.push(RepoDelegate.updateEntity(this.data.repoConfig._id, this.data.repoConfig));
-                    break;
                 case "jdbc": {
                     let resourceMapping = RepoDelegate.findGenericResourceMappingForRoute(this.data.repoConfig, "managed/"+managedObject.name);
                     if (resourceMapping && resourceMapping.searchableDefault !== true) {

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/AddManagedView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/AddManagedView.js
@@ -50,7 +50,7 @@ define([
         render: function(args, callback) {
             $.when(
                 ConfigDelegate.readEntity("managed"),
-                RepoDelegate.findRepoConfig()
+                RepoDelegate.getRepoConfig()
             ).then(_.bind(function(managedObjects, repoConfig) {
                 this.model.managedObjects = managedObjects;
                 this.data.repoConfig = repoConfig;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/EditManagedView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/EditManagedView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -99,7 +99,7 @@ define([
 
             $.when(
                 ConfigDelegate.readEntity("managed"),
-                RepoDelegate.findRepoConfig()
+                RepoDelegate.getRepoConfig()
             ).then(_.bind(function(managedObjects, repoConfig){
                 this.data.managedObjects = managedObjects;
                 this.data.repoConfig = repoConfig;
@@ -366,7 +366,6 @@ define([
                 }, this);
 
                 promises.push(ConfigDelegate.updateEntity("managed", {"objects" : this.data.managedObjects.objects}));
-                promises.push(RepoDelegate.deleteManagedObject(this.data.repoConfig, this.data.currentManagedObject.name));
 
                 $.when.apply($, promises).then(
                     function(){

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/ManagedListView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/managed/ManagedListView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 define([
@@ -60,7 +60,7 @@ define([
 
             $.when(
                 ConfigDelegate.readEntity("managed"),
-                RepoDelegate.findRepoConfig()
+                RepoDelegate.getRepoConfig()
             ).then(_.bind(function(managedObjects, repoConfig){
                 this.data.currentManagedObjects = _.sortBy(managedObjects.objects, 'name');
                 this.data.repoConfig = repoConfig;
@@ -207,7 +207,6 @@ define([
                 }, this));
 
                 promises.push(ConfigDelegate.updateEntity("managed", {"objects" : tempManaged}));
-                promises.push(RepoDelegate.deleteManagedObject(this.data.repoConfig, selectedItem.attr("data-managed-title")));
 
                 $.when.apply($, promises).then(() => {
                     selectedItem.remove();

--- a/openidm-ui/openidm-ui-admin/src/test/qunit/org/forgerock/openidm/ui/admin/delegates/RepoDelegateTest.js
+++ b/openidm-ui/openidm-ui-admin/src/test/qunit/org/forgerock/openidm/ui/admin/delegates/RepoDelegateTest.js
@@ -4,53 +4,29 @@ define([
     "org/forgerock/openidm/ui/admin/delegates/RepoDelegate"
 ], function (_, sinon, RepoDelegate) {
     var jdbcRepoConfig = {
-            "_id": "repo.jdbc",
-            "resourceMapping" : {
-                "genericMapping" : {
-                    "managed/user" : {
-                        "mainTable" : "managedobjects",
-                        "propertiesTable" : "managedobjectproperties",
-                        "searchableDefault" : false,
-                        "properties" : {
-                            "/userName" : {
-                                "searchable" : true
-                            },
-                            "/givenName" : {
-                                "searchable" : true
-                            }
+        "_id": "repo.jdbc",
+        "resourceMapping" : {
+            "genericMapping" : {
+                "managed/user" : {
+                    "mainTable" : "managedobjects",
+                    "propertiesTable" : "managedobjectproperties",
+                    "searchableDefault" : false,
+                    "properties" : {
+                        "/userName" : {
+                            "searchable" : true
+                        },
+                        "/givenName" : {
+                            "searchable" : true
                         }
                     }
                 }
             }
-        },
-        orientRepoConfig = {
-            "_id": "repo.orientdb",
-            "dbStructure" : {
-                "orientdbClass" : {
-                    "managed_user" : { },
-                    "managed_role" : { }
-                }
-            }
-        };
+        }
+    };
 
     QUnit.module('RepoDelegate Tests');
     QUnit.test("getRepoTypeFromConfig", function (assert) {
         assert.equal(RepoDelegate.getRepoTypeFromConfig({"_id": "repo.jdbc"}), "jdbc", "jdbc");
-        assert.equal(RepoDelegate.getRepoTypeFromConfig({"_id": "repo.orientdb"}), "orientdb", "orientdb");
-    });
-
-    QUnit.test("deleteManagedObject", function (assert) {
-        sinon.stub(RepoDelegate, "updateEntity").callsFake(function (id, updatedConfig) {
-            assert.ok(updatedConfig.dbStructure.orientdbClass.managed_user === undefined, "managed/user properly deleted from orient");
-            RepoDelegate.updateEntity.restore();
-        });
-
-        RepoDelegate.deleteManagedObject(_.cloneDeep(orientRepoConfig), "user");
-    });
-
-    QUnit.test("addManagedObjectToOrientClasses", function (assert) {
-        var updatedConfig = RepoDelegate.addManagedObjectToOrientClasses(_.cloneDeep(orientRepoConfig), "foo");
-        assert.ok(updatedConfig.dbStructure.orientdbClass.managed_foo !== undefined, "managed_foo added to orientdb");
     });
 
     QUnit.test("findGenericResourceMappingForRoute", function (assert){


### PR DESCRIPTION
This PR removes the OrientDB-related logic from the Admin UI. Support for OrientDB has been removed in #92 but for some reason the Admin UI was not completely cleaned up.

Fixes #118 and #119.