### PR TITLE
Upgrade all wrenicf connectors

### DIFF
--- a/custom-scripted-connector-bundler/src/main/resources/pom.template
+++ b/custom-scripted-connector-bundler/src/main/resources/pom.template
@@ -29,12 +29,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.wrensecurity.wrenicf.connector</groupId>
+        <groupId>org.wrensecurity.wrenicf.connectors</groupId>
         <artifactId>connector-bundle-parent</artifactId>
-        <version>1.5.3.2</version>
+        <version>1.5.4.1</version>
     </parent>
 
-    <groupId>org.wrensecurity.wrenicf.connector</groupId>
+    <groupId>org.wrensecurity.wrenicf.connectors</groupId>
     <artifactId>{{lower packageName}}-connector</artifactId>
     <version>1.5.{{version}}</version>
     <packaging>bundle</packaging>
@@ -69,15 +69,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.openicf.connectors</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>groovy-connector</artifactId>
-            <version>1.4.2.0</version>
+            <version>1.5.3.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrenicf.framework</groupId>
             <artifactId>connector-framework-core</artifactId>
-            <version>1.5.3.0</version>
         </dependency>
 
         <dependency>

--- a/openidm-provisioner-openicf/pom.xml
+++ b/openidm-provisioner-openicf/pom.xml
@@ -173,7 +173,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>groovy-connector</artifactId>
             <version>${openicf.groovyconnector.version}</version>
             <scope>test</scope>
@@ -241,17 +241,17 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.wrensecurity.wrenicf.connector</groupId>
+                                    <groupId>org.wrensecurity.wrenicf.connectors</groupId>
                                     <artifactId>xml-connector</artifactId>
                                     <version>${openicf.xmlconnector.version}</version>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wrensecurity.wrenicf.connector</groupId>
+                                    <groupId>org.wrensecurity.wrenicf.connectors</groupId>
                                     <artifactId>csvfile-connector</artifactId>
                                     <version>${openicf.csvconnector.version}</version>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wrensecurity.wrenicf.connector</groupId>
+                                    <groupId>org.wrensecurity.wrenicf.connectors</groupId>
                                     <artifactId>groovy-connector</artifactId>
                                     <version>${openicf.groovyconnector.version}</version>
                                 </artifactItem>
@@ -272,7 +272,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.wrensecurity.wrenicf.connector</groupId>
+                                    <groupId>org.wrensecurity.wrenicf.connectors</groupId>
                                     <artifactId>groovy-connector</artifactId>
                                     <version>${openicf.groovyconnector.version}</version>
                                     <classifier>samples</classifier>

--- a/openidm-provisioner-openicf/src/test/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderServiceTest.java
+++ b/openidm-provisioner-openicf/src/test/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderServiceTest.java
@@ -138,7 +138,7 @@ public class ConnectorInfoProviderServiceTest {
         // TODO: Find a better way to do this that doesn't include hard-coding the connector revision
         ConnectorReference ref =
                 new ConnectorReference(new ConnectorKey(
-                        "org.wrensecurity.wrenicf.connector.xml-connector", "1.5.3.0",
+                        "org.wrensecurity.wrenicf.connectors.xml-connector", "1.5.3.1",
                         "org.forgerock.openicf.connectors.xml.XMLConnector"));
         assertThat(testableConnectorInfoProvider.findConnectorInfo(ref))
                 .isNotNull()
@@ -151,11 +151,11 @@ public class ConnectorInfoProviderServiceTest {
         // TODO: Find a better way to do this that doesn't include hard-coding the connector revision
         ConnectorReference connectorReference =
                 new ConnectorReference(new ConnectorKey(
-                        "org.wrensecurity.wrenicf.connector.xml-connector", "1.5.3.0",
+                        "org.wrensecurity.wrenicf.connectors.xml-connector", "1.5.3.1",
                         "org.forgerock.openicf.connectors.xml.XMLConnector"));
         ConnectorInfo xmlConnectorInfo = null;
         ConnectorKey key =
-                new ConnectorKey("org.wrensecurity.wrenicf.connector.xml-connector", "1.5.3.0",
+                new ConnectorKey("org.wrensecurity.wrenicf.connectors.xml-connector", "1.5.3.1",
                         "org.forgerock.openicf.connectors.xml.XMLConnector");
         for (ConnectorInfo info : testableConnectorInfoProvider.getAllConnectorInfo()) {
             if (key.equals(info.getConnectorKey())) {

--- a/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-BusinessCSV.json
+++ b/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-BusinessCSV.json
@@ -1,8 +1,8 @@
 {
     "name" : "business",
     "connectorRef" : {
-        "bundleName" : "org.wrensecurity.wrenicf.connector.csvfile-connector",
-        "bundleVersion" : "1.5.1.4",
+        "bundleName" : "org.wrensecurity.wrenicf.connectors.csvfile-connector",
+        "bundleVersion" : "[1.5.3.0,1.5.4.0)",
         "connectorName" : "org.forgerock.openicf.csvfile.CSVFileConnector",
         "connectorHostRef" : "testServer"
     },

--- a/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-errorBadNativeType.json
+++ b/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-errorBadNativeType.json
@@ -1,8 +1,8 @@
 {
     "name": "errorBadNativeType",
     "connectorRef": {
-        "bundleName": "org.wrensecurity.wrenicf.connector.groovy-connector",
-        "bundleVersion": "1.5.3.0",
+        "bundleName": "org.wrensecurity.wrenicf.connectors.groovy-connector",
+        "bundleVersion": "[1.5.3.0,1.5.4.0)",
         "connectorName": "org.forgerock.openicf.connectors.groovy.ScriptedConnector"
     },
     "objectTypes": {

--- a/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-groovy.json
+++ b/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-groovy.json
@@ -1,8 +1,8 @@
 {
     "name": "groovy",
     "connectorRef": {
-        "bundleName": "org.wrensecurity.wrenicf.connector.groovy-connector",
-        "bundleVersion": "1.5.3.0",
+        "bundleName": "org.wrensecurity.wrenicf.connectors.groovy-connector",
+        "bundleVersion": "1.5.3.1",
         "connectorName": "org.forgerock.openicf.connectors.groovy.ScriptedConnector"
     },
     "poolConfigOption": {
@@ -28,7 +28,7 @@
         "enableAttributesToGetSearchResultsHandler": true
     },
     "configurationProperties": {
-        "scriptRoots": ["&{launcher.working.location}samples/groovy-connector-1.5.3.0/groovy/"],
+        "scriptRoots": ["&{launcher.working.location}samples/groovy-connector-1.5.3.1/groovy/"],
         "authenticateScriptFileName": "AuthenticateScript.groovy",
         "createScriptFileName": "CreateScript.groovy",
         "deleteScriptFileName": "DeleteScript.groovy",

--- a/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-groovyremote.json
+++ b/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-groovyremote.json
@@ -1,8 +1,8 @@
 {
     "name": "groovyremote",
     "connectorRef": {
-        "bundleName": "org.wrensecurity.wrenicf.connector.groovy-connector",
-        "bundleVersion": "1.5.3.0",
+        "bundleName": "org.wrensecurity.wrenicf.connectors.groovy-connector",
+        "bundleVersion": "1.5.3.1",
         "connectorName": "org.forgerock.openicf.connectors.groovy.ScriptedConnector",
         "connectorHostRef": "testServer"
     },
@@ -29,7 +29,7 @@
         "enableAttributesToGetSearchResultsHandler": true
     },
     "configurationProperties": {
-        "scriptRoots": ["&{launcher.working.location}samples/groovy-connector-1.5.3.0/groovy/"],
+        "scriptRoots": ["&{launcher.working.location}samples/groovy-connector-1.5.3.1/groovy/"],
         "authenticateScriptFileName": "AuthenticateScript.groovy",
         "createScriptFileName": "CreateScript.groovy",
         "deleteScriptFileName": "DeleteScript.groovy",

--- a/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-xml.json
+++ b/openidm-provisioner-openicf/src/test/resources/config/provisioner.openicf-xml.json
@@ -2,7 +2,7 @@
    "name" : "XML",
    "connectorRef" :
       {
-         "bundleName"    : "org.wrensecurity.wrenicf.connector.xml-connector",
+         "bundleName"    : "org.wrensecurity.wrenicf.connectors.xml-connector",
          "bundleVersion" : "[1.5.3.0,1.5.4.0)",
          "connectorName" : "org.forgerock.openicf.connectors.xml.XMLConnector"
       },

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/connector/AddConnectorView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/connector/AddConnectorView.js
@@ -91,8 +91,8 @@ define([
                 this.data.versionDisplay = _.filter(this.data.versionDisplay, _.bind(function(version) {
                     var bundleName = version.versions[0].bundleName,
                         excludes = [
-                            "org.wrensecurity.wrenicf.connector.ssh-connector",
-                            "org.wrensecurity.wrenicf.connector.groovy-connector"
+                            "org.wrensecurity.wrenicf.connectors.ssh-connector",
+                            "org.wrensecurity.wrenicf.connectors.groovy-connector"
                         ];
                     return !_.includes(excludes, bundleName);
                 }, this));

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -566,43 +566,43 @@
 
         <!-- Wren:ICF Connectors -->
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>xml-connector</artifactId>
             <version>${openicf.xmlconnector.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>csvfile-connector</artifactId>
             <version>${openicf.csvconnector.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>ldap-connector</artifactId>
             <version>${wrenicf.ldapconnector.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>databasetable-connector</artifactId>
             <version>${openicf.dbtableconnector.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>groovy-connector</artifactId>
             <version>${openicf.groovyconnector.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>ssh-connector</artifactId>
             <version>${openicf.sshconnector.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenicf.connector</groupId>
+            <groupId>org.wrensecurity.wrenicf.connectors</groupId>
             <artifactId>kerberos-connector</artifactId>
             <version>${openicf.kerberosconnector.version}</version>
         </dependency>

--- a/openidm-zip/src/main/assembly/zip.xml
+++ b/openidm-zip/src/main/assembly/zip.xml
@@ -106,7 +106,7 @@
                 <exclude>oro:oro</exclude>
                 <exclude>org.osgi:osgi.cmpn</exclude>
                 <exclude>org.wrensecurity.wrends:opendj-core</exclude>
-                <exclude>org.wrensecurity.wrenicf.connector:*</exclude>
+                <exclude>org.wrensecurity.wrenicf.connectors:*</exclude>
                 <exclude>org.wrensecurity.wrenidm:openidm-launcher</exclude>
                 <exclude>org.wrensecurity.wrenidm:openidm-shell</exclude>
                 <exclude>org.wrensecurity.wrenidm.tools:custom-scripted-connector-bundler</exclude>
@@ -155,7 +155,7 @@
             <useProjectArtifact>false</useProjectArtifact>
 
             <includes>
-                <include>org.wrensecurity.wrenicf.connector:*-connector</include>
+                <include>org.wrensecurity.wrenicf.connectors:*-connector</include>
             </includes>
         </dependencySet>
 
@@ -178,8 +178,8 @@
                 <include>org.apache.olingo:*</include>
                 <include>org.apache.tomcat:tomcat-jdbc</include>
                 <include>org.codehaus.groovy.modules.http-builder:http-builder</include>
-                <include>org.wrensecurity.wrenicf.connector:groovy-connector</include>
-                <include>org.wrensecurity.wrenicf.connector:ssh-connector</include>
+                <include>org.wrensecurity.wrenicf.connectors:groovy-connector</include>
+                <include>org.wrensecurity.wrenicf.connectors:ssh-connector</include>
                 <include>org.wrensecurity.wrends:opendj-*</include>
                 <include>oro:oro</include>
                 <include>xerces:xercesImpl</include>

--- a/pom.xml
+++ b/pom.xml
@@ -169,15 +169,15 @@
         <felix.webconsole.packageadmin.version>1.1.0</felix.webconsole.packageadmin.version>
 
         <!-- Wren:ICF Framework and Connector versions -->
-        <openicf.framework.version>1.5.4.0</openicf.framework.version>
-        <openicf.xmlconnector.version>1.5.3.0</openicf.xmlconnector.version>
-        <openicf.csvconnector.version>1.5.3.0</openicf.csvconnector.version>
-        <openicf.dbtableconnector.version>1.5.3.0</openicf.dbtableconnector.version>
+        <openicf.framework.version>1.5.4.1</openicf.framework.version>
+        <openicf.xmlconnector.version>1.5.3.1</openicf.xmlconnector.version>
+        <openicf.csvconnector.version>1.5.3.1</openicf.csvconnector.version>
+        <openicf.dbtableconnector.version>1.5.3.1</openicf.dbtableconnector.version>
         <openicf.remoteconnectorserver.version />
-        <openicf.groovyconnector.version>1.5.3.0</openicf.groovyconnector.version>
-        <openicf.sshconnector.version>1.5.3.0</openicf.sshconnector.version>
-        <openicf.kerberosconnector.version>1.5.3.0</openicf.kerberosconnector.version>
-        <wrenicf.ldapconnector.version>1.5.3.1</wrenicf.ldapconnector.version>
+        <openicf.groovyconnector.version>1.5.3.1</openicf.groovyconnector.version>
+        <openicf.sshconnector.version>1.5.3.1</openicf.sshconnector.version>
+        <openicf.kerberosconnector.version>1.5.3.1</openicf.kerberosconnector.version>
+        <wrenicf.ldapconnector.version>1.5.3.2</wrenicf.ldapconnector.version>
 
         <!-- OSGi bundles properties -->
         <openidm.osgi.import.before.defaults />


### PR DESCRIPTION
This PR upgrades all default Wren:ICF connectors to the latest version with a new grouId `org.wrensecurity.wrenicf.connectors`.