### PR TITLE
Upgrade assertj-core to 3.27.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -735,7 +735,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.19.0</version>
+                <version>3.27.7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR updates the `assertj-core` dependency, which has known security vulnerabilities.