### PR TITLE
Add support for JSON_LIST equals query operation

### DIFF
--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/query/MappedSQLQueryFilterVisitor.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/query/MappedSQLQueryFilterVisitor.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2024 Wren Security
+ * Copyright 2024-2026 Wren Security
  */
 package org.forgerock.openidm.repo.jdbc.impl.query;
 
@@ -53,6 +53,13 @@ public class MappedSQLQueryFilterVisitor extends StringSQLQueryFilterVisitor<Nam
             return visitBooleanAssertion(collector, config, operand, field, valueAssertion);
         }
 
+        if (config.valueType == ValueType.JSON_LIST) {
+            if (!"=".equals(operand)) {
+                throw new UnsupportedOperationException("Unsupported operand '" + operand + "' for JSON_LIST column");
+            }
+            return visitJsonListAssertion(collector, config, field, valueAssertion);
+        }
+
         String paramValue;
         try {
             paramValue = valueAssertion instanceof String
@@ -87,6 +94,11 @@ public class MappedSQLQueryFilterVisitor extends StringSQLQueryFilterVisitor<Nam
                 "CAST(" + config.columnName + " AS BIT)"
                 + " " + operand + " "
                 + "${" + paramName + "}");
+    }
+
+    protected StringSQLRenderer visitJsonListAssertion(NamedParameterCollector collector, MappedColumnConfig config,
+            JsonPointer field, Object valueAssertion) {
+        throw new UnsupportedOperationException("JSON_LIST value assertion is not supported for this database");
     }
 
     @Override

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/vendor/PostgreSQLMappedTableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/vendor/PostgreSQLMappedTableHandler.java
@@ -12,10 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
- * Portions Copyright 2024 Wren Security.
+ * Portions Copyright 2024-2026 Wren Security.
  */
 package org.forgerock.openidm.repo.jdbc.impl.vendor;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.forgerock.json.JsonPointer;
@@ -76,6 +77,19 @@ public class PostgreSQLMappedTableHandler extends MappedTableHandler {
                     MappedColumnConfig config, String operand, JsonPointer field, Object valueAssertion) {
                 String paramName = collector.register("v", valueAssertion);
                 return new StringSQLRenderer(config.columnName + " " + operand + " " + "${" + paramName + "}");
+            }
+
+            @Override
+            protected StringSQLRenderer visitJsonListAssertion(NamedParameterCollector collector,
+                    MappedColumnConfig config, JsonPointer field, Object valueAssertion) {
+                String jsonValue;
+                try {
+                    jsonValue = objectMapper.writeValueAsString(valueAssertion);
+                } catch (JsonProcessingException e) {
+                    throw new IllegalStateException("Failed to serialize JSON value.", e);
+                }
+                String paramName = collector.register("v", "[" + jsonValue + "]");
+                return new StringSQLRenderer(config.columnName + "::jsonb @> ${" + paramName + "}::jsonb");
             }
         };
     }

--- a/openidm-repo-jdbc/src/test/java/org/forgerock/openidm/repo/jdbc/impl/vendor/PostgreSQLMappedTableHandlerIT.java
+++ b/openidm-repo-jdbc/src/test/java/org/forgerock/openidm/repo/jdbc/impl/vendor/PostgreSQLMappedTableHandlerIT.java
@@ -11,11 +11,16 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2024 Wren Security
+ * Copyright 2024-2026 Wren Security
  */
 package org.forgerock.openidm.repo.jdbc.impl.vendor;
 
+import static org.forgerock.openidm.repo.jdbc.Constants.OBJECT_ID;
+import static org.testng.Assert.assertEquals;
+
 import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
 import org.forgerock.openidm.repo.jdbc.TableHandler;
 import org.forgerock.openidm.repo.jdbc.impl.handler.AbstractMappedTableHandlerTest;
 import org.testng.annotations.Test;
@@ -38,6 +43,39 @@ public class PostgreSQLMappedTableHandlerIT extends AbstractMappedTableHandlerTe
             getCommandConfig(),
             getExceptionHandler()
         );
+    }
+
+    @Test
+    public void testQueryFilterJsonListEquals() throws Exception {
+        createResource("resource-1", Map.of("tags", List.of("foo", "bar")));
+        createResource("resource-2", Map.of("tags", List.of("foo", "baz")));
+        createResource("resource-3", Map.of("tags", List.of(1, 2)));
+        createResource("resource-4", Map.of("tags", List.of(1, 3)));
+        createResource("resource-5", Map.of("tags", List.of(true)));
+        createResource("resource-6", Map.of("tags", List.of(false)));
+
+        var fooResult = queryResource("tags eq \"foo\"");
+        assertEquals(fooResult.size(), 2);
+        assertEquals(fooResult.stream().map(r -> r.get(OBJECT_ID)).sorted().toList(),
+                List.of("resource-1", "resource-2"));
+
+        var bazResult = queryResource("tags eq \"baz\"");
+        assertEquals(bazResult.size(), 1);
+        assertEquals(bazResult.stream().map(r -> r.get(OBJECT_ID)).toList(),
+                List.of("resource-2"));
+
+        var numberResult = queryResource("tags eq 1");
+        assertEquals(numberResult.size(), 2);
+        assertEquals(numberResult.stream().map(r -> r.get(OBJECT_ID)).toList(),
+                List.of("resource-3", "resource-4"));
+
+        var booleanResult = queryResource("tags eq true");
+        assertEquals(booleanResult.size(), 1);
+        assertEquals(booleanResult.stream().map(r -> r.get(OBJECT_ID)).toList(),
+                List.of("resource-5"));
+
+        var noResult = queryResource("tags eq \"hello\"");
+        assertEquals(noResult.size(), 0);
     }
 
 }


### PR DESCRIPTION
This PR adds `eq` query filter support for columns mapped with the `JSON_LIST` value type, allowing callers to check whether a string value is an element of the JSON array stored in a given column. The implementation introduces a protected `visitJsonListAssertion` hook in `MappedSQLQueryFilterVisitor` that is overridden in each vendor handler using the appropriate database-native JSON function — PostgreSQL uses the `JSONB` containment operator, MySQL uses `JSON_CONTAINS`, Oracle uses `JSON_EXISTS`, and MSSQL uses `OPENJSON`. Any operator other than equals on a JSON_LIST column will throw `UnsupportedOperationException`.