### PR TITLE
Fix workflow diagram fetching

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ProcessDefinitionView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ProcessDefinitionView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2026 Wren Security.
  */
 
 define([
@@ -33,23 +33,18 @@ define([
             },
             render: function(args, callback) {
                 this.model = new ProcessModel();
-
                 this.model.id = args[0];
 
-                this.model.fetch().then(_.bind(function () {
-
+                this.model.fetch({ data: { _fields: ",diagram" }}).then(_.bind(function () {
                     this.data.processDefinition = this.model.toJSON();
-
-                    this.data.diagramUrl = "/openidm/workflow/processdefinition/" + this.model.id + "?_fields=/diagram&_mimeType=image/png";
+                    this.data.diagramDataUri = "data:image/png;base64," + this.model.get("/diagram");
 
                     this.parentRender(_.bind(function(){
-
                         if (callback) {
                             callback();
                         }
-                    },this));
-
-                },this));
+                    }, this));
+                }, this));
             }
         });
 

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ProcessInstanceView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/workflow/ProcessInstanceView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023-2025 Wren Security.
+ * Portions Copyright 2023-2026 Wren Security.
  */
 
 define([
@@ -104,27 +104,31 @@ define([
 
                         this.data.processDefinition = processDefinition.toJSON();
 
+                        const renderCallback = _.bind(function() {
+                            this.parentRender(_.bind(function() {
+                                this.buildTasksGrid();
+                                if (callback) {
+                                    callback();
+                                }
+                            }, this));
+                        }, this);
+
                         if (this.data.processDefinition.processDiagramResourceName) {
-                            this.data.showDiagram = true;
-                            if (!this.model.get("endTime")) {
-                                this.data.diagramUrl = "/openidm/workflow/processinstance/" + this.model.id + "?_fields=/diagram&_mimeType=image/png";
-                            } else {
-                                this.data.diagramUrl = "/openidm/workflow/processdefinition/" + this.data.processDefinition._id + "?_fields=/diagram&_mimeType=image/png";
-                            }
+                            const diagramSource = !this.model.get("endTime") ? this.model : processDefinition;
+                            diagramSource.fetch({ data: { _fields: "diagram" }}).then(_.bind(function() {
+                                const diagramData = diagramSource.get("/diagram");
+                                if (diagramData) {
+                                    this.data.diagramDataUri = "data:image/png;base64," + diagramData;
+                                }
+                                renderCallback();
+                            }, this));
+                        } else {
+                            renderCallback();
                         }
 
-                        this.parentRender(_.bind(function(){
+                    }, this));
 
-                            this.buildTasksGrid();
-
-                            if (callback) {
-                                callback();
-                            }
-                        },this));
-
-                    },this));
-
-                },this));
+                }, this));
             },
             buildTasksGrid: function () {
                 var processTasks = new TaskInstanceCollection(_.sortBy(this.model.attributes.tasks, "startTime").reverse()),

--- a/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/ProcessDefinitionViewTemplate.html
+++ b/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/ProcessDefinitionViewTemplate.html
@@ -33,7 +33,7 @@
             <div class="tab-content" id="settings">
                 <div id="definitionTab" class="tab-pane active" role="tabpanel">
                     <div class="container">
-                        <img src="{{diagramUrl}}" class="diagramImage"/>
+                        <img src="{{diagramDataUri}}" class="diagramImage"/>
                     </div>
                 </div>
             </div>

--- a/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/ProcessInstanceViewTemplate.html
+++ b/openidm-ui/openidm-ui-admin/src/main/resources/templates/admin/workflow/ProcessInstanceViewTemplate.html
@@ -50,7 +50,7 @@
                 </div>
                 <div id="definitionTab" class="tab-pane" role="tabpanel">
                     <div class="container">
-                        <img src="{{diagramUrl}}" class="diagramImage"/>
+                        <img src="{{diagramDataUri}}" class="diagramImage"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR resolves an issue with the workflow diagram fetching after the removal of support for the `_mimeType` parameter (https://github.com/WrenSecurity/wrensec-commons/commit/65bbfd8c63c42e84ff7699aa5b82a22c08a12624).