### PR TITLE
Fix bcmail version

### DIFF
--- a/openidm-security/pom.xml
+++ b/openidm-security/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk18on</artifactId>
-            <version>1.80</version>
         </dependency>
 
         <dependency>

--- a/openidm-util/pom.xml
+++ b/openidm-util/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk18on</artifactId>
-            <version>1.80</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -759,6 +759,14 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bc-jdk18on-bom</artifactId>
+                <version>1.80.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR fixes the `bcmail` dependency version using the Bouncy Castle BOM.