### PR TITLE
Add support for multipart/alternative and multipart/mixed email notifications

### DIFF
--- a/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/impl/EmailClient.java
+++ b/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/impl/EmailClient.java
@@ -21,21 +21,31 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyright 2026 Wren Security.
  */
 package org.forgerock.openidm.external.email.impl;
 
+import org.eclipse.angus.mail.smtp.SMTPTransport;
 import org.eclipse.angus.mail.util.MailSSLSocketFactory;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.BadRequestException;
-
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Properties;
+import jakarta.activation.DataHandler;
+import jakarta.mail.BodyPart;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
 import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 
 /**
  * Email client.
@@ -96,25 +106,56 @@ public class EmailClient {
         session = Session.getInstance(props);
     }
 
-    /**
-     * Send the email according to the parameters in <em>params</em>:
-     *
-     * from : the From: address
-     * to : The To: recipients - a comma separated email address strings
-     * cc: The Cc: recipients - a comma separated email address strings
-     * bcc: The Bcc: recipients - a comma separated email address strings
-     * subject: The subject
-     * body : the message body
-     *
-     * @param   params
-     *          A JsonValue containing the {@code from}, {@code to}, {@code cc}, {@code bcc},
-     *          {@code subject}, and {@code body} parameters.
-     *
-     * @throws  BadRequestException
-     *          If the one or more of the {@code from}, {@code to}, {@code cc}, {@code bcc},
-     *          {@code subject}, or {@code body} parameters are missing or improperly formatted.
-     */
     public void send(JsonValue params) throws BadRequestException {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try {
+            // In OSGi, MailcapCommandMap scans META-INF/mailcap resources using the thread context
+            // classloader (TCCL). The TCCL on Felix HTTP threads does not have visibility into the
+            // angus-mail bundle, so the multipart/* DataContentHandler is never registered and
+            // Transport.sendMessage() fails with UnsupportedDataTypeException. Switching TCCL to
+            // the angus-mail bundle classloader (via class SMTPTransport) lets MailcapCommandMap
+            // find the mailcap file and register the handlers before the message is written.
+            // See https://github.com/eclipse-ee4j/angus-mail/issues/148
+            Thread.currentThread().setContextClassLoader(SMTPTransport.class.getClassLoader());
+            MimeMessage message = buildMessage(applyLegacyParams(params));
+            Transport transport = session.getTransport("smtp");
+            if (smtpAuth) {
+                transport.connect(username, password);
+            } else {
+                transport.connect();
+            }
+            transport.sendMessage(message, message.getAllRecipients());
+            transport.close();
+        } catch (MessagingException e) {
+            throw new BadRequestException(e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+    }
+
+    /**
+     * Build MimeMessage instance according to the parameters in <em>params</em>.
+     *
+     * <p>Envelope fields:
+     * <ul>
+     *   <li>{@code from} - From: address (falls back to configured default)</li>
+     *   <li>{@code to} - To: recipients, comma-separated</li>
+     *   <li>{@code cc} - Cc: recipients, comma-separated</li>
+     *   <li>{@code bcc} - Bcc: recipients, comma-separated</li>
+     *   <li>{@code subject} - message subject</li>
+     * </ul>
+     *
+     * <p>Body fields (semantic):
+     * <ul>
+     *   <li>{@code text} - plain-text body</li>
+     *   <li>{@code html} - HTML body</li>
+     *   <li>{@code attachments} - array of {@code {type, body (Base64), name}} objects</li>
+     * </ul>
+     * The correct multipart structure is chosen automatically based on which fields are present.
+     *
+     * @throws BadRequestException if required fields are absent or malformed.
+     */
+    protected MimeMessage buildMessage(JsonValue params) throws BadRequestException {
         InternetAddress from = null;
         InternetAddress[] to = null;
         InternetAddress[] cc = null;
@@ -126,13 +167,13 @@ public class EmailClient {
                 .asString();
 
         try {
-            if (!params.get("from").isNull()) {
+            if (params.get("from").isNotNull()) {
                 from = new InternetAddress(params.get("from").asString());
-            } else if (!params.get("_from").isNull()) {
+            } else if (params.get("_from").isNotNull()) {
                 from = new InternetAddress(params.get("_from").asString());
             } else if (fromAddr != null) {
                 from = new InternetAddress(fromAddr);
-            } else { // we don't have a from, need to throw
+            } else {
                 throw new BadRequestException("From: email address is absent");
             }
         } catch (AddressException ae) {
@@ -146,9 +187,9 @@ public class EmailClient {
         }
 
         try {
-            if (!params.get("cc").isNull()) {
+            if (params.get("cc").isNotNull()) {
                 cc = InternetAddress.parse(params.get("cc").asString());
-            } else if (!params.get("cc").isNull()) {
+            } else if (params.get("_cc").isNotNull()) {
                 cc = InternetAddress.parse(params.get("_cc").asString());
             }
         } catch (AddressException ae) {
@@ -156,9 +197,9 @@ public class EmailClient {
         }
 
         try {
-            if (!params.get("bcc").isNull()) {
+            if (params.get("bcc").isNotNull()) {
                 bcc = InternetAddress.parse(params.get("bcc").asString());
-            } else if (!params.get("_bcc").isNull()) {
+            } else if (params.get("_bcc").isNotNull()) {
                 bcc = InternetAddress.parse(params.get("_bcc").asString());
             }
         } catch (AddressException ae) {
@@ -166,7 +207,7 @@ public class EmailClient {
         }
 
         try {
-            Message message = new MimeMessage(session);
+            MimeMessage message = new MimeMessage(session);
             message.setFrom(from);
             message.setRecipients(Message.RecipientType.TO, to);
             if (cc != null) {
@@ -176,42 +217,80 @@ public class EmailClient {
                 message.setRecipients(Message.RecipientType.BCC, bcc);
             }
             message.setSubject(subject);
-
-            String type = params.get("type")
-                    .defaultTo(params.get("_type"))
-                    .defaultTo("text/plain")
-                    .asString();
-            Object body = params.get("body")
-                    .defaultTo(params.get("_body"))
-                    .getObject();
-
-            if (type.equalsIgnoreCase("text/plain") || type.equalsIgnoreCase("text/html") || type.equalsIgnoreCase("text/xml")) {
-                if (body != null && body instanceof String) {
-                    message.setContent(body, type);
-                } else {
-                    message.setText("<empty message>");
-                }
-            } else {
-                // no idea what this is... let's throw
-                throw new BadRequestException("Email type: " + type + " is not handled");
-            }
-
-            Transport transport = session.getTransport("smtp");
-
-            if (smtpAuth) {
-                transport.connect(username, password);
-            } else {
-                transport.connect();
-            }
+            setMessageContent(message, params);
             message.saveChanges();
-            transport.sendMessage(message, message.getAllRecipients());
-            transport.close();
-
+            return message;
         } catch (MessagingException e) {
             throw new BadRequestException(e);
         }
     }
 
-    public void format() {
+    private void setMessageContent(Message message, JsonValue params) throws MessagingException, BadRequestException {
+        String text = params.get("text").asString();
+        String html = params.get("html").asString();
+        JsonValue attachments = params.get("attachments");
+        if (attachments.size() == 0) {
+            setPartContent(message, text, html);
+        } else {
+            MimeMultipart mixed = new MimeMultipart("mixed");
+            MimeBodyPart bodyPart = new MimeBodyPart();
+            setPartContent(bodyPart, text, html);
+            mixed.addBodyPart(bodyPart);
+            for (JsonValue attachment : attachments) {
+                mixed.addBodyPart(buildAttachmentBodyPart(attachment));
+            }
+            message.setContent(mixed);
+        }
     }
+
+    private void setPartContent(Part part, String text, String html) throws MessagingException {
+        if (text != null && html != null) {
+            Multipart result = new MimeMultipart("alternative");
+            BodyPart textPart = new MimeBodyPart();
+            textPart.setContent(text, "text/plain; charset=UTF-8");
+            result.addBodyPart(textPart);
+            BodyPart htmlPart = new MimeBodyPart();
+            htmlPart.setContent(html, "text/html; charset=UTF-8");
+            result.addBodyPart(htmlPart);
+            part.setContent(result);
+        } else if (text != null) {
+            part.setContent(text, "text/plain; charset=UTF-8");
+        } else if (html != null) {
+            part.setContent(html, "text/html; charset=UTF-8");
+        } else {
+            part.setContent("", "text/plain; charset=UTF-8");
+        }
+    }
+
+    private BodyPart buildAttachmentBodyPart(JsonValue attachment) throws MessagingException, BadRequestException {
+        String type = attachment.get("type").required().asString();
+        String content = attachment.get("content").required().asString();
+        BodyPart bodyPart = new MimeBodyPart();
+        byte[] bytes = Base64.getDecoder().decode(content.getBytes(StandardCharsets.UTF_8));
+        bodyPart.setDataHandler(new DataHandler(new ByteArrayDataSource(bytes, type)));
+        String name = attachment.get("name").asString();
+        if (name != null) {
+            bodyPart.setFileName(name);
+        }
+        return bodyPart;
+    }
+
+    /**
+     * Translate legacy parameters to their current equivalents for backward compatibility.
+     */
+    private JsonValue applyLegacyParams(JsonValue params) {
+        JsonValue result = params.copy();
+        String body = result.get("body").defaultTo(result.get("_body")).asString();
+        if (body == null) {
+            return result;
+        }
+        String type = result.get("type").defaultTo(result.get("_type")).defaultTo("text/plain").asString();
+        if (type.equalsIgnoreCase("text/html")) {
+            result.put("html", body);
+        } else {
+            result.put("text", body);
+        }
+        return result;
+    }
+
 }

--- a/openidm-external-email/src/main/resources/org/forgerock/openidm/external/email/impl/sendActionRequest.json
+++ b/openidm-external-email/src/main/resources/org/forgerock/openidm/external/email/impl/sendActionRequest.json
@@ -59,15 +59,35 @@
       "type": "string",
       "default": "<empty subject>"
     },
-    "body": {
+    "text": {
       "type": "string",
-      "default": "<empty message>"
+      "description": "Plain text body"
     },
-    "type": {
-      "label": "MIME Type",
+    "html": {
       "type": "string",
-      "default": "text/plain"
+      "description": "HTML body"
+    },
+    "attachments": {
+      "type": "array",
+      "description": "File attachments",
+      "items": {
+        "type": "object",
+        "required": ["type", "body"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "MIME type of the attachment (e.g. application/pdf, image/png)"
+          },
+          "content": {
+            "type": "string",
+            "description": "Base64 encoded attachment content"
+          },
+          "name": {
+            "type": "string",
+            "description": "Filename"
+          }
+        }
+      }
     }
   }
 }
-

--- a/openidm-external-email/src/test/java/org/forgerock/openidm/external/email/impl/EmailClientTest.java
+++ b/openidm-external-email/src/test/java/org/forgerock/openidm/external/email/impl/EmailClientTest.java
@@ -1,0 +1,260 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security.
+ */
+package org.forgerock.openidm.external.email.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.array;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.forgerock.json.JsonValueException;
+import org.forgerock.json.resource.BadRequestException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Base64;
+
+public class EmailClientTest {
+
+    private static final String FROM = "sender@example.com";
+    private static final String TO = "recipient@example.com";
+    private static final String ATTACHMENT_BASE64 =
+            Base64.getEncoder().encodeToString(new byte[] { 1, 2, 3, 4, 5 });
+
+    private EmailClient client;
+
+    @BeforeClass
+    public void setUp() {
+        client = new EmailClient(json(object(field("from", FROM))));
+    }
+
+    @Test
+    public void textOnlyProducesPlainTextMessage() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("text", "Hello plain text")
+        )));
+
+        assertThat(message.getContentType()).startsWith("text/plain");
+        assertThat(message.getContent()).isEqualTo("Hello plain text");
+    }
+
+    @Test
+    public void htmlOnlyProducesHtmlMessage() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("html", "<b>Hello</b>")
+        )));
+
+        assertThat(message.getContentType()).startsWith("text/html");
+        assertThat(message.getContent()).isEqualTo("<b>Hello</b>");
+    }
+
+    @Test
+    public void textAndHtmlProducesMultipartAlternative() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("text", "Hello"),
+                field("html", "<b>Hello</b>")
+        )));
+
+        assertThat(message.getContentType()).startsWith("multipart/alternative");
+        MimeMultipart body = (MimeMultipart) message.getContent();
+        assertThat(body.getCount()).isEqualTo(2);
+        assertThat(body.getBodyPart(0).getContentType()).startsWith("text/plain");
+        assertThat(body.getBodyPart(0).getContent()).isEqualTo("Hello");
+        assertThat(body.getBodyPart(1).getContentType()).startsWith("text/html");
+        assertThat(body.getBodyPart(1).getContent()).isEqualTo("<b>Hello</b>");
+    }
+
+    @Test
+    public void textWithAttachmentProducesMultipartMixed() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("text", "See attached"),
+                field("attachments", array(object(
+                        field("type", "application/pdf"),
+                        field("content", ATTACHMENT_BASE64),
+                        field("name", "doc.pdf")
+                )))
+        )));
+
+        assertThat(message.getContentType()).startsWith("multipart/mixed");
+        MimeMultipart mixed = (MimeMultipart) message.getContent();
+        assertThat(mixed.getCount()).isEqualTo(2);
+        assertThat(mixed.getBodyPart(0).getContentType()).startsWith("text/plain");
+        assertThat(mixed.getBodyPart(0).getContent()).isEqualTo("See attached");
+        assertThat(mixed.getBodyPart(1).getContentType()).startsWith("application/pdf");
+        assertThat(mixed.getBodyPart(1).getFileName()).isEqualTo("doc.pdf");
+    }
+
+    @Test
+    public void htmlWithAttachmentProducesMultipartMixed() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("html", "<b>See attached</b>"),
+                field("attachments", array(object(
+                        field("type", "application/pdf"),
+                        field("content", ATTACHMENT_BASE64),
+                        field("name", "doc.pdf")
+                )))
+        )));
+
+        assertThat(message.getContentType()).startsWith("multipart/mixed");
+        MimeMultipart mixed = (MimeMultipart) message.getContent();
+        assertThat(mixed.getCount()).isEqualTo(2);
+        assertThat(mixed.getBodyPart(0).getContentType()).startsWith("text/html");
+        assertThat(mixed.getBodyPart(0).getContent()).isEqualTo("<b>See attached</b>");
+        assertThat(mixed.getBodyPart(1).getContentType()).startsWith("application/pdf");
+        assertThat(mixed.getBodyPart(1).getFileName()).isEqualTo("doc.pdf");
+    }
+
+    @Test
+    public void textAndHtmlWithAttachmentProducesNestedStructure() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("text", "Hello"),
+                field("html", "<b>Hello</b>"),
+                field("attachments", array(object(
+                        field("type", "application/pdf"),
+                        field("content", ATTACHMENT_BASE64),
+                        field("name", "doc.pdf")
+                )))
+        )));
+
+        assertThat(message.getContentType()).startsWith("multipart/mixed");
+        MimeMultipart mixed = (MimeMultipart) message.getContent();
+        assertThat(mixed.getCount()).isEqualTo(2);
+        assertThat(mixed.getBodyPart(0).getContentType()).startsWith("multipart/alternative");
+        MimeMultipart alternative = (MimeMultipart) mixed.getBodyPart(0).getContent();
+        assertThat(alternative.getCount()).isEqualTo(2);
+        assertThat(alternative.getBodyPart(0).getContentType()).startsWith("text/plain");
+        assertThat(alternative.getBodyPart(1).getContentType()).startsWith("text/html");
+        assertThat(mixed.getBodyPart(1).getContentType()).startsWith("application/pdf");
+        assertThat(mixed.getBodyPart(1).getFileName()).isEqualTo("doc.pdf");
+    }
+
+    @Test
+    public void multipleAttachmentsAreAllAdded() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("text", "See attached"),
+                field("attachments", array(
+                        object(field("type", "application/pdf"), field("content", ATTACHMENT_BASE64), field("name", "first.pdf")),
+                        object(field("type", "image/png"), field("content", ATTACHMENT_BASE64), field("name", "second.png"))
+                ))
+        )));
+
+        MimeMultipart mixed = (MimeMultipart) message.getContent();
+        assertThat(mixed.getCount()).isEqualTo(3);
+        assertThat(mixed.getBodyPart(1).getFileName()).isEqualTo("first.pdf");
+        assertThat(mixed.getBodyPart(2).getFileName()).isEqualTo("second.png");
+    }
+
+    @Test
+    public void noBodyFieldsProducesEmptyTextPlain() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO)
+        )));
+
+        assertThat(message.getContentType()).startsWith("text/plain");
+        assertThat(message.getContent()).isEqualTo("");
+    }
+
+    @Test
+    public void subjectDefaultsWhenAbsent() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("text", "Hello")
+        )));
+
+        assertThat(message.getSubject()).isEqualTo("<no subject>");
+    }
+
+    @Test
+    public void configuredFromIsUsedWhenFromAbsentInParams() throws Exception {
+        MimeMessage message = client.buildMessage(json(object(
+                field("to", TO),
+                field("text", "Hello")
+        )));
+
+        assertThat(message.getFrom()[0].toString()).isEqualTo(FROM);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class)
+    public void missingFromWithNoDefaultThrows() throws Exception {
+        EmailClient clientNoDefault = new EmailClient(json(object()));
+        clientNoDefault.buildMessage(json(object(
+                field("to", TO),
+                field("text", "Hello")
+        )));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class)
+    public void emptyFromAddressThrows() throws Exception {
+        client.buildMessage(json(object(
+                field("from", ""),
+                field("to", TO),
+                field("text", "Hello")
+        )));
+    }
+
+    @Test(expectedExceptions = JsonValueException.class)
+    public void attachmentWithMissingTypeThrows() throws Exception {
+        client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("attachments", array(object(
+                        field("content", ATTACHMENT_BASE64)
+                )))
+        )));
+    }
+
+    @Test(expectedExceptions = JsonValueException.class)
+    public void attachmentWithMissingBodyThrows() throws Exception {
+        client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("attachments", array(object(
+                        field("type", "application/pdf")
+                )))
+        )));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void attachmentWithInvalidBase64Throws() throws Exception {
+        client.buildMessage(json(object(
+                field("from", FROM),
+                field("to", TO),
+                field("attachments", array(object(
+                        field("type", "application/pdf"),
+                        field("content", "not valid base64!!!")
+                )))
+        )));
+    }
+}


### PR DESCRIPTION
This PR adds support for `multipart/alternative` and `multipart/mixed` email notifications. The email service now accepts `text` and `html` body fields and an `attachments` array, automatically selecting the correct MIME structure. The old `body/type` fields were removed. The following variants are currently supported:

**Plain text only**
```
{
  "to": "user@example.com",
  "subject": "Hello",
  "text": "This is a plain text message."
}
```

**HTML only**
```
{
  "to": "user@example.com",
  "subject": "Hello",
  "html": "<p>This is an <b>HTML</b> message.</p>"
}
```

**Text + HTML (multipart/alternative)**
```
{
  "to": "user@example.com",
  "subject": "Hello",
  "text": "This is a plain text message.",
  "html": "<p>This is an <b>HTML</b> message.</p>"
}
```

**With attachments (multipart/mixed)**
```
{
  "to": "user@example.com",
  "subject": "Report",
  "text": "Please find the report attached.",
  "html": "<p>Please find the report attached.</p>",
  "attachments": [
    {
      "type": "application/pdf",
      "content": "<base64-encoded content>",
      "name": "report.pdf"
    }
  ]
}
```