### PR TITLE
Add applyMappings sync action

### DIFF
--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ObjectMapping.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ObjectMapping.java
@@ -14,7 +14,7 @@
  * "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2018-2024 Wren Security.
+ * Portions Copyright 2018-2026 Wren Security.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -522,6 +522,26 @@ class ObjectMapping {
             return doSourceSync(context, resourceId, null, true, oldValue); // synchronous for now
         }
         return json(null);
+    }
+
+    /**
+     * Apply property mappings to the given source object and return the resulting target object.
+     * No synchronization is performed; this is a pure mapping evaluation for preview purposes.
+     *
+     * @param context the current request context
+     * @param source the source object to map
+     * @param oldSource the previous source object before a change, or {@code null} if not applicable
+     * @param target the starting target object, modified in place by the mapping
+     * @param existingTarget the full existing target object for reference in scripts, or {@code null}
+     * @param linkQualifier the link qualifier to use during mapping evaluation
+     * @return the target object after all property mappings have been applied
+     * @throws SynchronizationException if applying the mappings fails
+     */
+    public JsonValue applyMappings(Context context, JsonValue source, JsonValue oldSource,
+            JsonValue target, JsonValue existingTarget, String linkQualifier) throws SynchronizationException {
+        SourceSyncOperation operation = new SourceSyncOperation(this, context);
+        operation.applyMappings(context, source, oldSource, target, existingTarget, linkQualifier, null);
+        return target;
     }
 
     /**

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncOperation.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SyncOperation.java
@@ -910,7 +910,7 @@ abstract class SyncOperation {
      * @param reconContext Recon context or {@code null}
      * @throws SynchronizationException if applying the mappings fails.
      */
-    private void applyMappings(Context context, JsonValue source, JsonValue oldSource, JsonValue target,
+    protected void applyMappings(Context context, JsonValue source, JsonValue oldSource, JsonValue target,
             JsonValue existingTarget, String linkQualifier, ReconciliationContext reconContext) throws SynchronizationException {
         EventEntry measure = Publisher.start(objectMapping.getObjectMappingEventName(), source, null);
         try {

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SynchronizationService.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/SynchronizationService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2020 Wren Security
+ * Portions Copyright 2020-2026 Wren Security
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -98,7 +98,7 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
 
     /** Actions supported by this service. */
     public enum SyncServiceAction {
-        notifyCreate, notifyUpdate, notifyDelete, recon, performAction, getLinkedResources
+        notifyCreate, notifyUpdate, notifyDelete, recon, performAction, getLinkedResources, applyMappings
     }
 
     /** Logger */
@@ -362,6 +362,14 @@ public class SynchronizationService implements SingletonResourceProvider, Schedu
                     return newActionResponse(json(object(field("status", "OK")))).asPromise();
                 case getLinkedResources:
                     return getLinkedResources(context, resourcePath(request.getAdditionalParameter(ACTION_PARAM_RESOURCE_NAME)));
+                case applyMappings:
+                    logger.debug("Synchronization action=applyMappings, params={}", _params);
+                    ObjectMapping sourceMapping = mappings.getMapping(_params.get("mapping").required().asString());
+                    String linkQualifier = _params.get("linkQualifier").defaultTo(Link.DEFAULT_LINK_QUALIFIER).asString();
+                    JsonValue content = request.getContent();
+                    JsonValue mappedObject = sourceMapping.applyMappings(context, content.get("source").required(), content.get("oldSource"),
+                            content.get("target").defaultTo(object()), content.get("existingTarget"), linkQualifier);
+                    return newActionResponse(mappedObject).asPromise();
                 default:
                     throw new BadRequestException("Action" + request.getAction() + " is not supported.");
             }


### PR DESCRIPTION
This PR adds a new `applyMappings` action to the synchronization service that evaluates 
property mappings and transformation scripts against a caller-supplied source object and returns
the resulting target object. 

### Usage

```bash
curl \
  --request POST \
  --header "Content-Type: application/json" \
  --header "X-OpenIDM-Username: openidm-admin" \
  --header "X-OpenIDM-Password: openidm-admin" \
  --data '{
    "source": {
      "userName": "jdoe",
      "givenName": "John",
      "sn": "Doe",
      "mail": "jdoe@example.com"
    }
  }' \
  "http://localhost:8080/openidm/sync?_action=applyMappings&mapping=managedUser_ldapAccount"
```

**Example response**

```json
{
  "dn": "uid=jdoe,ou=people,dc=example,dc=com",
  "uid": "jdoe",
  "cn": "John Doe",
  "sn": "Doe",
  "mail": "jdoe@example.com"
}
```

**Request parameters:**

Parameter | Location | Required | Description
-- | -- | -- | --
mapping | query | yes | Name of the mapping to evaluate
linkQualifier | query | no | Link qualifier (defaults to *default*)
source | body | yes | Source object to map
oldSource | body | no | Previous source state, exposed to transform scripts
target | body | no | Starting target state (defaults to empty)
existingTarget | body | no | Existing target for reference in default mapping / role scripts

