### PR TITLE
Upgrade lodash to 4.18.1

### DIFF
--- a/openidm-ui/openidm-ui-admin/package-lock.json
+++ b/openidm-ui/openidm-ui-admin/package-lock.json
@@ -6525,9 +6525,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/openidm-ui/openidm-ui-admin/package.json
+++ b/openidm-ui/openidm-ui-admin/package.json
@@ -15,7 +15,7 @@
   },
   "overrides": {
     "globals": "17.4.0",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "puppeteer": "25.1.0"
   },
   "dependencies": {

--- a/openidm-ui/openidm-ui-api/package-lock.json
+++ b/openidm-ui/openidm-ui-api/package-lock.json
@@ -5921,9 +5921,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/openidm-ui/openidm-ui-api/package.json
+++ b/openidm-ui/openidm-ui-api/package.json
@@ -12,7 +12,7 @@
   },
   "overrides": {
     "globals": "17.4.0",
-    "lodash": "4.17.23"
+    "lodash": "4.18.1"
   },
   "scarfSettings": {
     "enabled": false

--- a/openidm-ui/openidm-ui-common/package-lock.json
+++ b/openidm-ui/openidm-ui-common/package-lock.json
@@ -6040,9 +6040,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/openidm-ui/openidm-ui-common/package.json
+++ b/openidm-ui/openidm-ui-common/package.json
@@ -15,6 +15,6 @@
     "yargs": "^17.7.2"
   },
   "overrides": {
-    "lodash": "4.17.23"
+    "lodash": "4.18.1"
   }
 }

--- a/openidm-ui/openidm-ui-enduser/package-lock.json
+++ b/openidm-ui/openidm-ui-enduser/package-lock.json
@@ -6111,9 +6111,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/openidm-ui/openidm-ui-enduser/package.json
+++ b/openidm-ui/openidm-ui-enduser/package.json
@@ -14,7 +14,7 @@
   },
   "overrides": {
     "globals": "17.4.0",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "puppeteer": "25.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
This PR updates the `lodash` dependency, which has known security vulnerabilities.