### PR TITLE
Fix email client classloading

### DIFF
--- a/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/impl/EmailClient.java
+++ b/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/impl/EmailClient.java
@@ -103,34 +103,26 @@ public class EmailClient {
         }
 
         fromAddr = config.get(CONFIG_MAIL_FROM).asString();
-        session = Session.getInstance(props);
+        session = withAngusMailClassLoader(() -> Session.getInstance(props));
     }
 
     public void send(JsonValue params) throws BadRequestException {
-        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        try {
-            // In OSGi, MailcapCommandMap scans META-INF/mailcap resources using the thread context
-            // classloader (TCCL). The TCCL on Felix HTTP threads does not have visibility into the
-            // angus-mail bundle, so the multipart/* DataContentHandler is never registered and
-            // Transport.sendMessage() fails with UnsupportedDataTypeException. Switching TCCL to
-            // the angus-mail bundle classloader (via class SMTPTransport) lets MailcapCommandMap
-            // find the mailcap file and register the handlers before the message is written.
-            // See https://github.com/eclipse-ee4j/angus-mail/issues/148
-            Thread.currentThread().setContextClassLoader(SMTPTransport.class.getClassLoader());
-            MimeMessage message = buildMessage(applyLegacyParams(params));
-            Transport transport = session.getTransport("smtp");
-            if (smtpAuth) {
-                transport.connect(username, password);
-            } else {
-                transport.connect();
+        withAngusMailClassLoader(() -> {
+            try {
+                MimeMessage message = buildMessage(applyLegacyParams(params));
+                Transport transport = session.getTransport("smtp");
+                if (smtpAuth) {
+                    transport.connect(username, password);
+                } else {
+                    transport.connect();
+                }
+                transport.sendMessage(message, message.getAllRecipients());
+                transport.close();
+                return null;
+            } catch (MessagingException e) {
+                throw new BadRequestException(e);
             }
-            transport.sendMessage(message, message.getAllRecipients());
-            transport.close();
-        } catch (MessagingException e) {
-            throw new BadRequestException(e);
-        } finally {
-            Thread.currentThread().setContextClassLoader(tccl);
-        }
+        });
     }
 
     /**
@@ -291,6 +283,32 @@ public class EmailClient {
             result.put("text", body);
         }
         return result;
+    }
+
+    /**
+     * Runs {@code action} with the thread context classloader (TCCL) temporarily switched to the
+     * angus-mail bundle classloader.
+     *
+     * <p>In OSGi, jakarta.mail resolves several services (e.g. {@code StreamProvider} used by
+     * {@code Session}, and the {@code MailcapCommandMap} entries used by {@code Transport}) via
+     * the TCCL. The TCCL on Felix SCR/DS and HTTP threads has no visibility into the angus-mail
+     * bundle, so these lookups fail unless the TCCL is temporarily switched to a classloader that
+     * can see angus-mail.
+     * See https://github.com/eclipse-ee4j/angus-mail/issues/148
+     */
+    private static <T, E extends Exception> T withAngusMailClassLoader(ThrowingSupplier<T, E> action) throws E {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(SMTPTransport.class.getClassLoader());
+        try {
+            return action.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T, E extends Exception> {
+        T get() throws E;
     }
 
 }


### PR DESCRIPTION
This PR fixes the following `EmailClient` class loading error that sometimes occured during Wren:IDM startup:

```
WARNING: Configuration invalid, can not start external email client service.
java.lang.IllegalStateException: No provider of jakarta.mail.util.StreamProvider was found
        at jakarta.mail.util.FactoryFinder.find(FactoryFinder.java:61)
        at jakarta.mail.util.StreamProvider.provider(StreamProvider.java:199)
        at jakarta.mail.Session.<init>(Session.java:263)
        at jakarta.mail.Session.getInstance(Session.java:333)
        at org.forgerock.openidm.external.email.impl.EmailClient.<init>(EmailClient.java:106)
        at org.forgerock.openidm.external.email.impl.EmailServiceImpl.activate(EmailServiceImpl.java:137)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.apache.felix.scr.impl.inject.methods.BaseMethod.invokeMethod(BaseMethod.java:257)
        at org.apache.felix.scr.impl.inject.methods.BaseMethod.access$500(BaseMethod.java:41)
        at org.apache.felix.scr.impl.inject.methods.BaseMethod$Resolved.invoke(BaseMethod.java:701)
        at org.apache.felix.scr.impl.inject.methods.BaseMethod.invoke(BaseMethod.java:544)
        at org.apache.felix.scr.impl.inject.methods.ActivateMethod.invoke(ActivateMethod.java:317)
        at org.apache.felix.scr.impl.inject.methods.ActivateMethod.invoke(ActivateMethod.java:307)
        at org.apache.felix.scr.impl.manager.SingleComponentManager.createImplementationObject(SingleComponentManager.java:354)
        at org.apache.felix.scr.impl.manager.SingleComponentManager.createComponent(SingleComponentManager.java:115)
        at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:1002)
        at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:975)
        at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:920)
        at org.apache.felix.framework.ServiceRegistrationImpl.getFactoryUnchecked(ServiceRegistrationImpl.java:349)
        at org.apache.felix.framework.ServiceRegistrationImpl.getService(ServiceRegistrationImpl.java:249)
        at org.apache.felix.framework.ServiceRegistry.getService(ServiceRegistry.java:362)
        at org.apache.felix.framework.Felix.getService(Felix.java:3984)
        at org.apache.felix.framework.BundleContextImpl.getService(BundleContextImpl.java:450)
...
```