### PR TITLE
Upgrade postgres jdbc driver to 42.7.13

### DIFF
--- a/openidm-repo-jdbc/pom.xml
+++ b/openidm-repo-jdbc/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <version>42.7.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -643,7 +643,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.1</version>
+            <version>42.7.13</version>
         </dependency>
 
         <!-- Scripted REST Groovy dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     </issueManagement>
 
     <properties>
-        <pgpVerifyKeysVersion>1.9.15</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.9.19</pgpVerifyKeysVersion>
 
         <maven.compiler.release>17</maven.compiler.release>
 


### PR DESCRIPTION
This PR upgrades the PostgreSQL driver due to security issues in the previous version.